### PR TITLE
fix: pre-create appsettings.extra.json on Windows

### DIFF
--- a/docs/user/docs/getting-started.md
+++ b/docs/user/docs/getting-started.md
@@ -34,6 +34,17 @@ The installer will ask which edition (CE or EE) and which version to install. Th
     irm https://raw.githubusercontent.com/Corsinvest/cv4pve-admin/main/install.ps1 | iex
     ```
 
+    !!! info "Windows note"
+        The installer automatically creates `appsettings.extra.json` as a file before starting Docker.
+        This is required because Docker Desktop on Windows creates it as a directory if it doesn't already exist.
+
+        If you installed **manually** (without the installer), run this once in the installation directory before `docker compose up -d`:
+        ```powershell
+        $dataDir = (Get-Content .env | Where-Object { $_ -match '^DATA_DIR=' }) -replace '^DATA_DIR=', ''
+        New-Item -ItemType Directory -Force -Path "$dataDir\cv4pve-admin\config" | Out-Null
+        New-Item -ItemType File -Force -Path "$dataDir\cv4pve-admin\config\appsettings.extra.json" | Out-Null
+        ```
+
 !!! success "Installation Complete"
     After installation completes, open your browser to **http://localhost:8080**
 

--- a/install.ps1
+++ b/install.ps1
@@ -103,6 +103,15 @@ foreach ($file in $Files) {
 Copy-Item $ComposeFile docker-compose.yaml
 Write-Host "Configured: $ComposeFile -> docker-compose.yaml"
 
+# Pre-create appsettings.extra.json as file (Windows: Docker creates it as directory if missing)
+$dataDir = (Get-Content .env | Where-Object { $_ -match '^DATA_DIR=' }) -replace '^DATA_DIR=', ''
+$dataDir = $dataDir.Trim()
+New-Item -ItemType Directory -Force -Path "$dataDir\cv4pve-admin\config" | Out-Null
+if (-not (Test-Path "$dataDir\cv4pve-admin\config\appsettings.extra.json")) {
+    New-Item -ItemType File -Force -Path "$dataDir\cv4pve-admin\config\appsettings.extra.json" | Out-Null
+    Write-Host "Created: $dataDir\cv4pve-admin\config\appsettings.extra.json"
+}
+
 # Update .env file
 $envContent = Get-Content .env
 if ($Tag -ne "latest") {


### PR DESCRIPTION
## Problem

On Windows, Docker Desktop creates bind-mounted paths as **directories** if they don't exist before container startup — even when the mount target is a file. This causes `appsettings.extra.json` to be created as a directory instead of a file, breaking the application startup.

The `cv4pve-admin-init` container runs `touch /app/config/appsettings.extra.json`, but Docker has already created the directory before any container starts.

## Changes

- **`install.ps1`**: automatically pre-creates `appsettings.extra.json` as a file (reading `DATA_DIR` from `.env`) after downloading files, before `docker compose up -d`
- **`docs/user/docs/getting-started.md`**: adds a Windows note explaining the issue and providing the manual command for users who install without the installer

## Test plan

- [ ] Run `install.ps1` on Windows — verify `data/cv4pve-admin/config/appsettings.extra.json` is created as a **file**
- [ ] Run `docker compose up -d` — verify application starts correctly
- [ ] Verify Linux/macOS install is unaffected