### PR TITLE
fix: fix installer interactive prompts and improve tag UX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Default: normalize line endings to LF on commit
+* text=auto eol=lf
+
+# Windows scripts: keep CRLF
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Shell scripts and config: always LF
+*.sh text eol=lf
+*.env text eol=lf
+adminctl text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/docs/user/docs/getting-started.md
+++ b/docs/user/docs/getting-started.md
@@ -20,7 +20,7 @@ Before installing cv4pve-admin, ensure you have:
 
 ## Quick Installation
 
-The installer will ask which edition (CE or EE) and which version to install. The default is `latest` (stable release) — just press Enter to accept. If you need a specific version (e.g. `rc1`, `v2.0.0`), enter it when prompted. The version can also be changed later by editing `CV4PVE_ADMIN_TAG` in `.env`.
+The installer will ask which edition (CE or EE) and which version to install. The default is `latest` (stable release) — just press Enter to accept. If you need a specific version (e.g. `2.0.0-rc1`, `2.0.0`), enter it when prompted. The version can also be changed later by editing `CV4PVE_ADMIN_TAG` in `.env`.
 
 === "Linux / macOS"
 

--- a/install.ps1
+++ b/install.ps1
@@ -42,6 +42,23 @@ switch ($EditionChoice) {
 }
 
 Write-Host ""
+# Show available tags from Docker Hub
+Write-Host "Fetching available tags from Docker Hub..."
+$DockerRepo = "corsinvest/cv4pve-admin"
+if ($ComposeFile -eq "docker-compose-ee.yaml") { $DockerRepo = "corsinvest/cv4pve-admin-ee" }
+try {
+    $TagsJson = Invoke-RestMethod -Uri "https://hub.docker.com/v2/repositories/$DockerRepo/tags/?page_size=5" -UseBasicParsing
+    $RecentTags = ($TagsJson.results | Where-Object { $_.name -ne "latest" } | Select-Object -First 3 | ForEach-Object { $_.name }) -join "  "
+    if ($RecentTags) {
+        Write-Host "  Recent tags: latest  $RecentTags"
+    } else {
+        Write-Host "  Recent tags: latest"
+    }
+} catch {
+    Write-Host "  Recent tags: latest"
+}
+Write-Host "  All tags: https://hub.docker.com/r/$DockerRepo/tags"
+Write-Host ""
 # Ask for version tag
 $Tag = Read-Host "Docker image tag (default: latest)"
 $Tag = $Tag.Trim()

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ echo "Choose edition:"
 echo "  1) Community Edition (CE)"
 echo "  2) Enterprise Edition (EE)"
 echo ""
-read -p "Select [1-2] (default: 1): " EDITION_CHOICE
+read -p "Select [1-2] (default: 1): " EDITION_CHOICE </dev/tty
 EDITION_CHOICE=${EDITION_CHOICE:-1}
 
 case $EDITION_CHOICE in
@@ -43,8 +43,23 @@ case $EDITION_CHOICE in
 esac
 
 echo ""
+# Show available tags from Docker Hub
+echo "Fetching available tags from Docker Hub..."
+DOCKER_REPO="corsinvest/cv4pve-admin"
+if [ "$COMPOSE_FILE" = "docker-compose-ee.yaml" ]; then
+    DOCKER_REPO="corsinvest/cv4pve-admin-ee"
+fi
+TAGS=$(curl -s "https://hub.docker.com/v2/repositories/${DOCKER_REPO}/tags/?page_size=5" \
+    | grep -o '"name":"[^"]*"' | grep -v '"name":"latest"' | head -3 | sed 's/"name":"//;s/"//' | tr '\n' '  ')
+if [ -n "$TAGS" ]; then
+    echo "  Recent tags: latest  $TAGS"
+else
+    echo "  Recent tags: latest"
+fi
+echo "  All tags: https://hub.docker.com/r/${DOCKER_REPO}/tags"
+echo ""
 # Ask for version tag
-read -p "Docker image tag (default: latest): " TAG
+read -p "Docker image tag (default: latest): " TAG </dev/tty
 TAG=$(echo "$TAG" | xargs)  # Trim whitespace
 if [ -z "$TAG" ]; then
     TAG="latest"
@@ -54,7 +69,7 @@ echo "Using tag: $TAG"
 echo ""
 # Ask for PostgreSQL password
 while true; do
-    read -sp "PostgreSQL password (press ENTER for default): " POSTGRES_PASSWORD
+    read -sp "PostgreSQL password (press ENTER for default): " POSTGRES_PASSWORD </dev/tty
     echo ""
     POSTGRES_PASSWORD=$(echo "$POSTGRES_PASSWORD" | xargs)  # Trim whitespace
 

--- a/src/docker/.env
+++ b/src/docker/.env
@@ -26,8 +26,8 @@ DATA_DIR=./data
 # ==============================================================================
 # Application Version
 # ==============================================================================
-# Docker image tag to use (latest, rc2, 1.0.0, etc.)
-# For testing pre-release versions, change to rc2 or specific version
+# Docker image tag to use. Examples: latest, 2.0.0-rc1, 2.0.0
+# Check available tags at: https://hub.docker.com/r/corsinvest/cv4pve-admin/tags
 CV4PVE_ADMIN_TAG=latest
 
 # ==============================================================================

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -138,29 +138,29 @@ To test Release Candidate (RC) or specific versions before they become stable:
 
 ### 1. Edit `.env` file
 
-Change the version tag:
+Edit `.env` and change `CV4PVE_ADMIN_TAG` to the desired tag:
 ```bash
-CV4PVE_ADMIN_TAG=rc2
+CV4PVE_ADMIN_TAG=2.0.0-rc1
 ```
 
-Available tags:
+Available tags (check [Docker Hub](https://hub.docker.com/r/corsinvest/cv4pve-admin/tags) for the full list):
 - `latest` - Stable release (default)
-- `rc2`, `rc3`, etc. - Release Candidates
-- `1.0.0`, `1.1.0` - Specific versions
+- `2.0.0-rc1`, `2.0.0-rc2`, etc. - Release Candidates
+- `2.0.0`, `2.1.0` - Specific versions
 
 **Quick commands to change version:**
 
 Linux/Mac (bash):
 ```bash
-# Replace VERSION with your desired tag (rc2, rc3, 1.0.0, latest, etc.)
-VERSION=rc2
+# Replace VERSION with your desired tag (e.g. 2.0.0-rc1, 2.0.0, latest)
+VERSION=2.0.0-rc1
 sed -i "s/^CV4PVE_ADMIN_TAG=.*/CV4PVE_ADMIN_TAG=$VERSION/" .env
 ```
 
 Windows (PowerShell):
 ```powershell
-# Replace VERSION with your desired tag (rc2, rc3, 1.0.0, latest, etc.)
-$VERSION = "rc2"
+# Replace VERSION with your desired tag (e.g. 2.0.0-rc1, 2.0.0, latest)
+$VERSION = "2.0.0-rc1"
 (Get-Content .env) -replace '^CV4PVE_ADMIN_TAG=.*', "CV4PVE_ADMIN_TAG=$VERSION" | Set-Content .env
 ```
 


### PR DESCRIPTION
## Summary

- **`install.sh`**: fix `read` commands with `</dev/tty` so interactive prompts work when script is piped via `curl | bash` (root cause of #142)
- **`install.sh` + `install.ps1`**: show available Docker Hub tags (based on edition CE/EE) before asking for version, with link to full tag list
- **`install.sh`, `adminctl`, `.env`**: convert CRLF → LF (files were broken on Linux/macOS)
- **`.gitattributes`**: enforce LF for shell scripts and `.env`, CRLF for `.ps1`
- **`src/docker/README.md`**: correct tag format examples (`2.0.0-rc1` instead of `rc2`)
- **`src/docker/.env`**: improve tag comment with link to Docker Hub tags
- **`docs/getting-started.md`**: update tag format examples

Fixes #142

## Test plan

- [ ] Run `curl -fsSL .../install.sh | bash` on Linux/macOS — verify interactive prompts appear correctly
- [ ] Run `irm .../install.ps1 | iex` on Windows — verify tags are fetched and shown
- [ ] Verify CE shows `corsinvest/cv4pve-admin` tags, EE shows `corsinvest/cv4pve-admin-ee` tags