### PR TITLE
fix: skip BuildInfo initialization when running EF tools at design-time

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
@@ -22,6 +22,8 @@ public static class BuildInfo
 
     static BuildInfo()
     {
+        if (Helpers.ApplicationHelper.IsRunningInEfTool) { return; }
+
         var assembly = Assembly.GetEntryAssembly()!;
 
         Version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0];


### PR DESCRIPTION
## Summary
- `BuildInfo` static constructor crashes at EF design-time because the entry assembly is `ef.dll` (no `EditionAttribute`)
- Added guard `if (ApplicationHelper.IsRunningInEfTool) { return; }` to skip initialization when running EF CLI tools

## Test plan
- [ ] Run `dotnet ef migrations add ...` — should succeed without `NullReferenceException`
- [ ] Normal app startup — `BuildInfo` properties still populated correctly