### PR TITLE
docs: add Telegram bot setup instructions to Bots module

### DIFF
--- a/docs/user/docs/modules/bots.md
+++ b/docs/user/docs/modules/bots.md
@@ -45,3 +45,22 @@ Remote Proxmox VE cluster management through Telegram chatbot. Execute commands,
     Execute operations through chat-based commands.
 
 </div>
+
+## Set Up Your Telegram Bot
+
+To connect the Bots module to Telegram, you need to create a bot via **BotFather** and copy the generated token into the module settings.
+
+1. Open the Telegram app on your phone or computer.
+
+2. Search for the [**BotFather**](https://web.telegram.org/k/#@BotFather) bot — he's the official Telegram bot for creating and managing bots.
+
+3. Type `/newbot` to create a new bot. Follow the instructions:
+    - Choose a **display name** (e.g. `My PVE Bot`)
+    - Choose a **username** — must be unique and end in `bot` (e.g. `my_pve_bot`)
+
+4. BotFather will generate an **API token** (e.g. `707587383:AAHD9D***************`).
+
+5. Copy the token and paste it into the **Token** field in the Bots module settings.
+
+!!! tip
+    If you are creating a bot just for testing, prefix the username with your name to make it unique (e.g. `john_pve_bot`).

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
@@ -51,9 +51,6 @@
             <p>Search for the “<a href="https://web.telegram.org/k/#@@BotFather" target="_blank">BotFather</a>” telegram bot (he’s the one that’ll assist you with creating and managing your bot)</p>
         </li>
         <li>
-            <p>Type <strong>/help</strong> to see all possible commands the botfather can handle</p>
-        </li>
-        <li>
             <p>
                 Click on or type <strong>/newbot</strong>  to create a new bot. Follow instructions and make a new name for your bot. If you are making a bot just for experimentation, it can be useful to namespace your bot by placing your name before it in its username, since it has to be a unique name. Although, its screen name can be whatever you like.
                 I have chosen “Frank Test PVE Bot” as the screen name and “frank_test_pve_bot” as its username.


### PR DESCRIPTION
## Summary

- Add **Set Up Your Telegram Bot** section to `bots.md` with step-by-step instructions to create a bot via BotFather and configure the token
- Remove redundant `/help` step from both the docs and the in-app `Render.razor` dialog

## Test plan

- [ ] Verify `bots.md` renders correctly in MkDocs
- [ ] Verify in-app info dialog still works correctly without the `/help` step