### PR TITLE
feat: add icons to RadzenFormField Start slot across UI components

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Widgets/Check/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Widgets/Check/RenderSettings.razor
@@ -6,7 +6,10 @@
 @implements ISettingsParameter<CheckSettings>
 
 <RadzenFormField Text="@L["Days to analyze"]" AllowFloatingLabel="false" class="rz-w-100">
-    <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    <Start><RadzenIcon Icon="calendar_today" /></Start>
+    <ChildContent>
+        <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    </ChildContent>
 </RadzenFormField>
 
 @code

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Widgets/Check/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Widgets/Check/RenderSettings.razor
@@ -6,7 +6,10 @@
 @implements ISettingsParameter<CheckSettings>
 
 <RadzenFormField Text="@L["Days to analyze"]" AllowFloatingLabel="false" class="rz-w-100">
-    <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    <Start><RadzenIcon Icon="calendar_today" /></Start>
+    <ChildContent>
+        <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    </ChildContent>
 </RadzenFormField>
 
 @code

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Components/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Components/RenderSettings.razor
@@ -27,6 +27,7 @@
             </PasswordField>
 
             <RadzenFormField Text="@L["Chats Id"]" AllowFloatingLabel="false" class="rz-w-100">
+                <Start><RadzenIcon Icon="chat" /></Start>
                 <ChildContent>
                     <RadzenTextBox Name="@nameof(Model.Telegram.ChatsId)" @bind-Value="@Model.Telegram.ChatsId" />
                 </ChildContent>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
@@ -20,21 +20,27 @@
 
 
         <RadzenFormField Text="@L["Users"]" AllowFloatingLabel="false" Visible="Chats.Count() > 1">
-            <RadzenDropDown TValue="long"
-                            TextProperty="@nameof(Data.User)"
-                            ValueProperty="@nameof(Data.ChatId)"
-                            AllowClear="true"
-                            @bind-Value="@ChatId"
-                            title="@L["ChatId: {0}", ChatId]"
-                            Data="@Chats" />
+            <Start><RadzenIcon Icon="person" /></Start>
+            <ChildContent>
+                <RadzenDropDown TValue="long"
+                                TextProperty="@nameof(Data.User)"
+                                ValueProperty="@nameof(Data.ChatId)"
+                                AllowClear="true"
+                                @bind-Value="@ChatId"
+                                title="@L["ChatId: {0}", ChatId]"
+                                Data="@Chats" />
+            </ChildContent>
         </RadzenFormField>
 
         <RadzenFormField Text="@L["Message"]" AllowFloatingLabel="false" class="rz-w-100" Visible="Chats.Count() > 1">
-            <RadzenTextBox @bind-Value="@Message"
-                           @onkeyup="KeyUpAsync"
-                           class="rz-w-100"
-                           type="search"
-                           Placeholder="@L["Enter your message..."]" />
+            <Start><RadzenIcon Icon="chat" /></Start>
+            <ChildContent>
+                <RadzenTextBox @bind-Value="@Message"
+                               @onkeyup="KeyUpAsync"
+                               class="rz-w-100"
+                               type="search"
+                               Placeholder="@L["Enter your message..."]" />
+            </ChildContent>
         </RadzenFormField>
     </RadzenStack>
 </RadzenStack>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/WidgetDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/WidgetDialog.razor
@@ -5,6 +5,9 @@
 @inherits AdminComponentBase
 
 <RadzenFormField Text="@L["Title (text or html)"]" AllowFloatingLabel="false">
+    <Start>
+        <RadzenIcon Icon="title" />
+    </Start>
     <ChildContent>
         <RadzenTextBox Name="@nameof(Model.Widget.Title)" @bind-Value="@Model.Widget.Title" />
     </ChildContent>
@@ -18,6 +21,9 @@
         <RadzenAccordionItem Text="Style" Icon="style">
             <RadzenStack Orientation="Orientation.Vertical">
                 <RadzenFormField Text="@L["Title CSS"]" AllowFloatingLabel="false">
+                    <Start>
+                        <RadzenIcon Icon="style" />
+                    </Start>
                     <ChildContent>
                         <RadzenTextArea Name="@nameof(Model.Widget.TitleCss)" @bind-Value="@Model.Widget.TitleCss" />
                     </ChildContent>
@@ -27,6 +33,9 @@
                 </RadzenFormField>
 
                 <RadzenFormField Text="@L["Body CSS"]" AllowFloatingLabel="false">
+                    <Start>
+                        <RadzenIcon Icon="style" />
+                    </Start>
                     <ChildContent>
                         <RadzenTextArea Name="@nameof(Model.Widget.BodyCss)" @bind-Value="@Model.Widget.BodyCss" />
                     </ChildContent>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Widgets/WebContent/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Widgets/WebContent/RenderSettings.razor
@@ -26,20 +26,30 @@
 {
     case ContentType.Link:
         <RadzenFormField Text="@L["Url"]" AllowFloatingLabel="false" class="rz-w-100">
-            <RadzenTextBox Name="@nameof(Settings.Url)" @bind-Value="@Settings.Url" />
+            <Start><RadzenIcon Icon="link" /></Start>
+            <ChildContent>
+                <RadzenTextBox Name="@nameof(Settings.Url)" @bind-Value="@Settings.Url" />
+            </ChildContent>
         </RadzenFormField>
 
         <RadzenFormField Text="@L["Text"]" AllowFloatingLabel="false" class="rz-w-100">
-            <RadzenTextBox Name="@nameof(Settings.Text)" @bind-Value="@Settings.Text" />
+            <Start><RadzenIcon Icon="text_fields" /></Start>
+            <ChildContent>
+                <RadzenTextBox Name="@nameof(Settings.Text)" @bind-Value="@Settings.Text" />
+            </ChildContent>
         </RadzenFormField>
 
         <RadzenFormField Text="@L["Icon"]" AllowFloatingLabel="false" class="rz-w-100">
-            <RadzenTextBox Name="@nameof(Settings.Icon)" @bind-Value="@Settings.Icon" />
+            <Start><RadzenIcon Icon="interests" /></Start>
+            <ChildContent>
+                <RadzenTextBox Name="@nameof(Settings.Icon)" @bind-Value="@Settings.Icon" />
+            </ChildContent>
         </RadzenFormField>
         break;
 
     case ContentType.Iframe:
         <RadzenFormField Text="@L["Url"]" AllowFloatingLabel="false" class="rz-w-100">
+            <Start><RadzenIcon Icon="link" /></Start>
             <ChildContent>
                 <RadzenTextBox Name="@nameof(Settings.Url)"
                                Value="@Settings.Url"
@@ -53,10 +63,13 @@
 
     case ContentType.Html:
         <RadzenFormField Text="@L["HTML Content"]" AllowFloatingLabel="false" class="rz-w-100">
-            <RadzenTextArea Name="@nameof(Settings.Html)"
-                            @bind-Value="@Settings.Html"
-                            Rows="10"
-                            Style="width: 100%; font-family: monospace;" />
+            <Start><RadzenIcon Icon="code" /></Start>
+            <ChildContent>
+                <RadzenTextArea Name="@nameof(Settings.Html)"
+                                @bind-Value="@Settings.Html"
+                                Rows="10"
+                                Style="width: 100%; font-family: monospace;" />
+            </ChildContent>
         </RadzenFormField>
         break;
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/IssuesDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/IssuesDialog.razor
@@ -8,6 +8,7 @@
 @implements IModelParameter<IgnoredIssue>
 
 <RadzenFormField Text="@L["Id Resource"]" AllowFloatingLabel="false">
+    <Start><RadzenIcon Icon="tag" /></Start>
     <ChildContent>
         <RadzenTextBox Name="@nameof(Model.IdResource)" @bind-Value="@Model.IdResource" />
     </ChildContent>
@@ -55,6 +56,7 @@
 </RadzenFormField>
 
 <RadzenFormField Text="@L["Sub Context"]" AllowFloatingLabel="false">
+    <Start><RadzenIcon Icon="subdirectory_arrow_right" /></Start>
     <ChildContent>
         <RadzenTextBox Name="@nameof(Model.SubContext)" @bind-Value="@Model.SubContext" />
     </ChildContent>
@@ -64,6 +66,7 @@
 </RadzenFormField>
 
 <RadzenFormField Text="@L["Description"]" AllowFloatingLabel="false">
+    <Start><RadzenIcon Icon="notes" /></Start>
     <ChildContent>
         <RadzenTextBox Name="@nameof(Model.Description)" @bind-Value="@Model.Description" />
     </ChildContent>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.MetricsExporter/Components/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.MetricsExporter/Components/RenderSettings.razor
@@ -15,6 +15,7 @@
                          IconOff="pause_circle" />
 
             <RadzenFormField Text="@L["Prefix"]" AllowFloatingLabel="false" class="rz-w-100">
+                <Start><RadzenIcon Icon="label" /></Start>
                 <ChildContent>
                     <RadzenTextBox Name="@nameof(Model.Prometheus.ExporterPrefix)" @bind-Value="@Model.Prometheus.ExporterPrefix" />
                 </ChildContent>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Notifier/Smtp/Components/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Notifier/Smtp/Components/Render.razor
@@ -16,6 +16,7 @@
         <SmtpEmailConfigEdit @bind-Config="context.SmtpConfig" />
 
         <RadzenFormField Text="@L["To Addresses"]" AllowFloatingLabel="false">
+            <Start><RadzenIcon Icon="email" /></Start>
             <ChildContent>
                 <RadzenTextArea Name="@nameof(context.ToAddresses)" @bind-Value="@context.ToAddresses" Rows="3" />
             </ChildContent>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Widgets/Check/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Widgets/Check/RenderSettings.razor
@@ -6,7 +6,10 @@
 @implements ISettingsParameter<CheckSettings>
 
 <RadzenFormField Text="@L["Days to analyze"]" AllowFloatingLabel="false" class="rz-w-100">
-    <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    <Start><RadzenIcon Icon="calendar_today" /></Start>
+    <ChildContent>
+        <RadzenNumeric @bind-Value="@Settings.Day" Min="1" />
+    </ChildContent>
 </RadzenFormField>
 
 @code

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/ScanDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/ScanDialog.razor
@@ -12,6 +12,7 @@
 
                 <RadzenStack Orientation="Orientation.Horizontal">
                     <RadzenFormField Text="@L["Vm Ids"]" AllowFloatingLabel="false">
+                        <Start><RadzenIcon Icon="computer" /></Start>
                         <ChildContent>
                             <RadzenTextBox Name="@nameof(Model.VmIds)" @bind-Value="@Model.VmIds" />
                         </ChildContent>
@@ -32,6 +33,7 @@
 
                 <RadzenStack Orientation="Orientation.Horizontal">
                     <RadzenFormField Text="@L["Node Names"]" AllowFloatingLabel="false">
+                        <Start><RadzenIcon Icon="dns" /></Start>
                         <ChildContent>
                             <RadzenTextBox Name="@nameof(Model.NodeNames)" @bind-Value="@Model.NodeNames" />
                         </ChildContent>
@@ -52,6 +54,7 @@
 
                 <RadzenStack Orientation="Orientation.Horizontal">
                     <RadzenFormField Text="@L["Storage Names"]" AllowFloatingLabel="false">
+                        <Start><RadzenIcon Icon="storage" /></Start>
                         <ChildContent>
                             <RadzenTextBox Name="@nameof(Model.StorageNames)" @bind-Value="@Model.StorageNames" />
                         </ChildContent>


### PR DESCRIPTION
## Summary
- Added `<Start><RadzenIcon /></Start>` to all RadzenFormField components missing an icon
- Covers AutoSnap, BackupAnalytics, Bots, Dashboard, Diagnostic, MetricsExporter, Notifier, ReplicationAnalytics, SystemReport modules

## Test plan
- [ ] Verify icons appear correctly in each form field
- [ ] Verify no layout regressions