### PR TITLE
fix: resolve nullable CS8618 warnings in BuildInfo.cs

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
@@ -8,15 +8,15 @@ namespace Corsinvest.ProxmoxVE.Admin.Core;
 
 public static class BuildInfo
 {
-    public static readonly string Version;
-    public static readonly string PreRelease;
+    public static readonly string Version = string.Empty;
+    public static readonly string PreRelease = string.Empty;
     public static readonly bool IsTesting;
     public const int TestingExpirationMonths = 3;
 
-    public static readonly string Edition;
+    public static readonly string Edition = string.Empty;
     public static readonly bool IsEnterpriseEdition;
-    public static readonly string EditionFull;
-    public static readonly string RepoDockerHub;
+    public static readonly string EditionFull = string.Empty;
+    public static readonly string RepoDockerHub = string.Empty;
     public static readonly DateTime BuildDate;
     public static readonly bool IsTestingExpired;
 


### PR DESCRIPTION
## Summary
- Initialize static readonly string fields with `string.Empty` to resolve CS8618 nullable warnings
- Needed because static constructor has an early return path (`if (IsRunningInEfTool) { return; }`)

## Test plan
- [ ] Build completes without CS8618 warnings