### PR TITLE
feat: place send test email button inline with email field

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/SmtpConfig.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/SmtpConfig.razor
@@ -16,23 +16,24 @@
             <RadzenStack Gap="1rem">
                 <RadzenText TextStyle="TextStyle.H6">@L["Test SMTP Configuration"]</RadzenText>
 
-                <RadzenFormField Text="@L["Test Email Address"]" AllowFloatingLabel="false" class="rz-w-100">
-                    <Start>
-                        <RadzenIcon Icon="email" />
-                    </Start>
-                    <ChildContent>
-                        <RadzenTextBox @bind-Value="TestEmailAddress"
-                                       Placeholder="user@example.com"
-                                       class="rz-w-100" />
-                    </ChildContent>
-                </RadzenFormField>
+                <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.End">
+                    <RadzenFormField Text="@L["Test Email Address"]" AllowFloatingLabel="false" style="flex: 1">
+                        <Start>
+                            <RadzenIcon Icon="email" />
+                        </Start>
+                        <ChildContent>
+                            <RadzenTextBox @bind-Value="TestEmailAddress"
+                                           Placeholder="user@example.com"
+                                           class="rz-w-100" />
+                        </ChildContent>
+                    </RadzenFormField>
 
-                <RadzenButton Icon="send"
-                              Text="@L["Send Test Email"]"
-                              ButtonStyle="ButtonStyle.Success"
-                              Click="SendTestEmailAsync"
-                              Disabled="IsSendingTest"
-                              class="rz-w-100" />
+                    <RadzenButton Icon="send"
+                                  Text="@L["Send"]"
+                                  ButtonStyle="ButtonStyle.Success"
+                                  Click="SendTestEmailAsync"
+                                  Disabled="IsSendingTest" />
+                </RadzenStack>
             </RadzenStack>
         </RadzenCard>
     </RadzenColumn>


### PR DESCRIPTION
## Summary
- Moved "Send" test email button next to the email field using `RadzenStack Horizontal` with `AlignItems.End`
- Changed button text from "Send Test Email" to "Send" for conciseness

## Test plan
- [ ] Verify button is aligned to the right of the email field
- [ ] Verify test email is sent correctly