### PR TITLE
feat: improve Dashboard reset logic, add save icon and update build props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,6 @@
     <VersionPreRelease>$([System.Text.RegularExpressions.Regex]::Match($(Version), '-(.+)$').Groups[1].Value)</VersionPreRelease>
     <IsTesting Condition="'$(VersionPreRelease)' != ''">true</IsTesting>
     <IsTesting Condition="'$(VersionPreRelease)' == ''">false</IsTesting>
-    <TestingExpirationMonths>3</TestingExpirationMonths>
 
     <!-- TESTING constant when pre-release version -->
     <DefineConstants Condition="'$(IsTesting)' == 'true'">$(DefineConstants);TESTING</DefineConstants>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor.cs
@@ -319,6 +319,9 @@ public partial class Dashboard(IDbContextFactory<ModuleDbContext> dbContextFacto
         InEditing = false;
         ShowGrid = false;
 
+        //reset resolution
+        SelectedScreenResolution = ScreenResolutions[0];
+
         await RefreshDataAsync();
     }
     #endregion

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/SettingsAccordion.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/SettingsAccordion.razor
@@ -9,7 +9,7 @@
         <Items>
             @foreach (var item in Sections)
             {
-                <RadzenAccordionItem Text="@item.Title" Icon="@item.Icon" >
+                <RadzenAccordionItem Text="@item.Title" Icon="@item.Icon">
                     <Template>
                         <div><strong>@item.Title</strong></div>
                         @if (!string.IsNullOrEmpty(item.Description))
@@ -21,7 +21,10 @@
                         <DynamicComponent Type="@item.ComponentType" Parameters="@GetParameters()" />
 
                         <div class="rz-mt-4">
-                            <RadzenButton Text="@L["Save changes"]" ButtonStyle="ButtonStyle.Primary" Click="@(() => SaveSectionAsync(item))" />
+                            <RadzenButton Text="@L["Save changes"]"
+                                          ButtonStyle="ButtonStyle.Primary"
+                                          Icon="save"                                         
+                                          Click="@(() => SaveSectionAsync(item))" />
                         </div>
                     </ChildContent>
                 </RadzenAccordionItem>


### PR DESCRIPTION
## Summary
- Dashboard: reset SelectedScreenResolution to first item on cleanup
- SettingsAccordion: add `save` icon to "Save changes" button
- Directory.Build.props: remove obsolete TestingExpirationMonths property

## Test plan
- [ ] Verify dashboard screen resolution resets correctly
- [ ] Verify save icon appears on settings accordion button