### PR TITLE
fix: replace try/catch ObjectDisposedException with _disposed flag

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetDonutBase.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetDonutBase.razor.cs
@@ -35,6 +35,7 @@ public abstract partial class WidgetDonutBase<TSettings> : IModuleWidget<TSettin
     }
 
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private bool _disposed;
 
     protected void SetOk(int count) => Set("Ok", count, Colors.Success);
     protected void SetKo(int count) => Set("Ko", count, Colors.Danger);
@@ -60,6 +61,7 @@ public abstract partial class WidgetDonutBase<TSettings> : IModuleWidget<TSettin
 
     public async Task RefreshDataAsync()
     {
+        if (_disposed) { return; }
         if (!await _refreshLock.WaitAsync(0)) { return; }
         try
         {
@@ -67,7 +69,7 @@ public abstract partial class WidgetDonutBase<TSettings> : IModuleWidget<TSettin
         }
         finally
         {
-            try { _refreshLock?.Release(); } catch (ObjectDisposedException) { }
+            if (!_disposed) { _refreshLock?.Release(); }
         }
     }
 
@@ -75,6 +77,7 @@ public abstract partial class WidgetDonutBase<TSettings> : IModuleWidget<TSettin
 
     public virtual void Dispose()
     {
+        _disposed = true;
         _refreshLock?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetThumbDetailsBase.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetThumbDetailsBase.razor.cs
@@ -14,6 +14,7 @@ public abstract partial class WidgetThumbDetailsBase<TWidgetSettings>(IAdminServ
 
     protected IEnumerable<Data> Items { get; set; } = [];
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private bool _disposed;
     protected bool ShowIcon { get; set; } = true;
 
     protected string Message { get; set; } = default!;
@@ -37,6 +38,7 @@ public abstract partial class WidgetThumbDetailsBase<TWidgetSettings>(IAdminServ
 
     public async Task RefreshDataAsync()
     {
+        if (_disposed) { return; }
         if (!await _refreshLock.WaitAsync(0)) { return; }
         try
         {
@@ -44,7 +46,7 @@ public abstract partial class WidgetThumbDetailsBase<TWidgetSettings>(IAdminServ
         }
         finally
         {
-            try { _refreshLock?.Release(); } catch (ObjectDisposedException) { }
+            if (!_disposed) { _refreshLock?.Release(); }
         }
     }
 
@@ -52,6 +54,7 @@ public abstract partial class WidgetThumbDetailsBase<TWidgetSettings>(IAdminServ
 
     public void Dispose()
     {
+        _disposed = true;
         _refreshLock?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/ClusterUsage/Gauge.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/ClusterUsage/Gauge.razor.cs
@@ -17,6 +17,7 @@ public partial class Gauge(IAdminService adminService) : IModuleWidget<object>, 
     private bool Initalized { get; set; }
 
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private bool _disposed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -26,6 +27,7 @@ public partial class Gauge(IAdminService adminService) : IModuleWidget<object>, 
 
     public async Task RefreshDataAsync()
     {
+        if (_disposed) { return; }
         if (!await _refreshLock.WaitAsync(0)) { return; }
         try
         {
@@ -33,7 +35,7 @@ public partial class Gauge(IAdminService adminService) : IModuleWidget<object>, 
         }
         finally
         {
-            try { _refreshLock?.Release(); } catch (ObjectDisposedException) { }
+            if (!_disposed) { _refreshLock?.Release(); }
         }
     }
 
@@ -54,6 +56,7 @@ public partial class Gauge(IAdminService adminService) : IModuleWidget<object>, 
 
     public void Dispose()
     {
+        _disposed = true;
         _refreshLock?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/ClusterUsage/GaugeStacked.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/ClusterUsage/GaugeStacked.razor.cs
@@ -17,6 +17,7 @@ public partial class GaugeStacked(IAdminService adminService) : IModuleWidget<ob
     private bool Initalized { get; set; }
 
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private bool _disposed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -26,6 +27,7 @@ public partial class GaugeStacked(IAdminService adminService) : IModuleWidget<ob
 
     public async Task RefreshDataAsync()
     {
+        if (_disposed) { return; }
         if (!await _refreshLock.WaitAsync(0)) { return; }
         try
         {
@@ -33,7 +35,7 @@ public partial class GaugeStacked(IAdminService adminService) : IModuleWidget<ob
         }
         finally
         {
-            try { _refreshLock?.Release(); } catch (ObjectDisposedException) { }
+            if (!_disposed) { _refreshLock?.Release(); }
         }
     }
 
@@ -54,6 +56,7 @@ public partial class GaugeStacked(IAdminService adminService) : IModuleWidget<ob
 
     public void Dispose()
     {
+        _disposed = true;
         _refreshLock?.Dispose();
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## Summary
- Replace `try { _refreshLock?.Release(); } catch (ObjectDisposedException) { }` with a cleaner `_disposed` flag pattern across all 13 components
- Set `_disposed = true` before `Dispose()` to prevent new entries
- Guard `Release()` with `if (!_disposed)` to avoid using a disposed semaphore
- Applied to: `ResourcesEx`, `Replication`, `Charts`, `Disks`, `Snapshot/Manager`, `WidgetDonutBase`, `WidgetInfoBase`, `WidgetSparklineBase`, `WidgetThumbDetailsBase`, `ClusterUsage/Gauge`, `ClusterUsage/GaugeStacked`, `ClusterUsage/Grid`, `Maps/Render`

## Test plan
- [ ] Verify components dispose cleanly without `ObjectDisposedException` in logs
- [ ] Verify refresh still works during normal operation