### PR TITLE
feat: add vpn_key icon to Access Type field

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/ClusterConfig/ClusterSettingsDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/ClusterConfig/ClusterSettingsDialog.razor
@@ -58,6 +58,9 @@
     <RadzenStack Orientation="Orientation.Vertical">
         <RadzenStack Orientation="Orientation.Horizontal">
             <RadzenFormField Text="@L["Access Type"]" AllowFloatingLabel="false" class="rz-w-100">
+                <Start>
+                    <RadzenIcon Icon="vpn_key" />
+                </Start>
                 <ChildContent>
                     <RadzenDropDown TValue="ClusterAccessType"
                                     Name="@nameof(Model.AccessType)"


### PR DESCRIPTION
## Summary
- Added `vpn_key` icon to the Access Type `RadzenFormField` in `ClusterSettingsDialog`

## Test plan
- [ ] Open cluster settings dialog and verify the vpn_key icon appears on the Access Type field