### PR TITLE
fix: Telegram doc link + pre-release subscription note in getting-started

### DIFF
--- a/docs/user/docs/getting-started.md
+++ b/docs/user/docs/getting-started.md
@@ -1,5 +1,9 @@
 # Installation Guide
 
+!!! tip "Pre-release versions (RC, Beta, ...)"
+    Pre-release versions such as `rc`, `beta`, or `alpha` (e.g. `2.0.0-rc1`) **do not require a subscription** — all EE features are unlocked for testing purposes.
+    Once you upgrade to a stable release, a valid subscription will be required to use EE features.
+
 !!! warning "v2 is not compatible with v1"
     cv4pve-admin v2 is a **complete rewrite** and is not compatible with v1.
     There is currently no migration path from v1 to v2 — a fresh installation is required.
@@ -44,6 +48,10 @@ The installer will ask which edition (CE or EE) and which version to install. Th
         New-Item -ItemType Directory -Force -Path "$dataDir\cv4pve-admin\config" | Out-Null
         New-Item -ItemType File -Force -Path "$dataDir\cv4pve-admin\config\appsettings.extra.json" | Out-Null
         ```
+
+!!! tip "Pre-release versions (RC, Beta, ...)"
+    Pre-release versions such as `rc`, `beta`, or `alpha` (e.g. `2.0.0-rc1`) **do not require a subscription** — all EE features are unlocked for testing purposes.
+    Once you upgrade to a stable release, a valid subscription will be required to use EE features.
 
 !!! success "Installation Complete"
     After installation completes, open your browser to **http://localhost:8080**

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Bots/Telegram/Components/Render.razor
@@ -13,10 +13,10 @@
                       title="@L["Open Telegram Web"]"
                       aria-label="@L["Open Telegram Web"]" />
 
-        <RadzenButton Click="ShowInfo"
+        <RadzenButton Click="@(() => browserService.OpenAsync("https://corsinvest.github.io/cv4pve-admin/modules/bots/#set-up-your-telegram-bot", "_blank"))"
                       Icon="info"
-                      title="@L["Open info"]"
-                      aria-label="@L["Open info"]" />
+                      title="@L["Open documentation"]"
+                      aria-label="@L["Open documentation"]" />
 
 
         <RadzenFormField Text="@L["Users"]" AllowFloatingLabel="false" Visible="Chats.Count() > 1">
@@ -47,26 +47,4 @@
 
 
 @code {
-    private async Task ShowInfo()
-    {
-        await dialogService.OpenAsync(L["Set up your bot in Telegram"], _ =>
-                @<div>
-    <p>Go to the Telegram app on your phone or computer and…</p>
-    <ul>
-        <li>
-            <p>Search for the “<a href="https://web.telegram.org/k/#@@BotFather" target="_blank">BotFather</a>” telegram bot (he’s the one that’ll assist you with creating and managing your bot)</p>
-        </li>
-        <li>
-            <p>
-                Click on or type <strong>/newbot</strong>  to create a new bot. Follow instructions and make a new name for your bot. If you are making a bot just for experimentation, it can be useful to namespace your bot by placing your name before it in its username, since it has to be a unique name. Although, its screen name can be whatever you like.
-                I have chosen “Frank Test PVE Bot” as the screen name and “frank_test_pve_bot” as its username.
-            </p>
-        </li>
-        <li>
-            <p>Congratulations! You have created your first bot. You should see a new API token generated for it (for example my newly generated token is <strong>707587383:AAHD9D***************</strong>). Now copy the <strong>token</strong> in te settings.</p>
-        </li>
-    </ul>
-</div>
-            , new DialogOptions { CloseDialogOnOverlayClick = true });
-    }
 }


### PR DESCRIPTION
## Summary
- **Bots/Telegram**: replaced inline `ShowInfo` dialog with a button that opens the MkDocs documentation at the `#set-up-your-telegram-bot` anchor
- **getting-started.md**: added tip at the top of the page clarifying that pre-release versions (rc, beta, alpha) do not require a subscription

## Test plan
- [ ] Open Bots > Telegram setup, click the info button and verify it opens the correct MkDocs anchor
- [ ] Check getting-started page and verify the pre-release tip appears at the top