### PR TITLE
fix: remove Feature Request from feedback template, fix HelpMenu typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,5 +1,5 @@
 name: 💬 Feedback
-description: Share your feedback, suggestions, or feature requests
+description: Share your feedback or suggestions about cv4pve-admin
 title: "[Feedback]: "
 labels: ["feedback"]
 body:
@@ -34,7 +34,6 @@ body:
       label: Feedback Type
       description: What type of feedback is this?
       options:
-        - Feature Request
         - Improvement Suggestion
         - User Experience
         - General Feedback

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor
@@ -35,6 +35,6 @@
 
         <RadzenProfileMenuItem Text="@L["Keyboard Shortcuts"]" Icon="keyboard" Value="@("shortcuts")" />
         <RadzenProfileMenuItem Text="@L["Release notes"]" Icon="celebration" Value="@("release-notes")" />
-        <RadzenProfileMenuItem Text="@L["Provide Feedback"]" Icon="feedback" Path="@($"https://github.com/Corsinvest/cv4pve-admin/issues/new?template=feedback.yml&edition={BuildInfo.Edition}&version={BuildInfo.Version}")" Target="_balnk" />
+        <RadzenProfileMenuItem Text="@L["Provide Feedback"]" Icon="feedback" Path="@($"https://github.com/Corsinvest/cv4pve-admin/issues/new?template=feedback.yml&edition={BuildInfo.Edition}&version={BuildInfo.Version}")" Target="_blank" />
     </ChildContent>
 </RadzenProfileMenu>


### PR DESCRIPTION
## Summary

- Remove `Feature Request` option from `feedback.yml` dropdown — overlaps with the dedicated `feature_request.yml` template
- Update `feedback.yml` description to clarify it's for general feedback/suggestions only
- Fix typo `_balnk` → `_blank` in `HelpMenu.razor`

## Test plan

- [ ] Open "Provide Feedback" from the app help menu — link opens in new tab
- [ ] Verify `feedback.yml` template on GitHub shows 4 options: Improvement Suggestion, User Experience, General Feedback, Other