### PR TITLE
feat: improve release notification in HelpMenu

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor
@@ -6,19 +6,17 @@
 
 <RadzenProfileMenu ShowIcon="false" Click="OnMenuClick">
     <Template>
-        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center">
+        <div style="position: relative; display: inline-flex;">
             <RadzenIcon Icon="help_outline" Style="font-size: 1.5rem;" />
-        </RadzenStack>
-    </Template>
-    <ChildContent>
-        <RadzenStack Style="width:300px; padding: 10px;" Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
-            <RadzenText TextStyle="TextStyle.Body2" Style="font-weight: bold;">@L["Your"] @AppSettings.AppName @L["version"] 🚀</RadzenText>
             @if (NewRelease != null)
             {
-                <RadzenBadge BadgeStyle="BadgeStyle.Danger" Text="@L["Update ASAP"]" IsPill="true" />
+                <span style="position: absolute; top: 0; right: 0; width: 8px; height: 8px; background-color: #ff1744; border-radius: 50%;"></span>
             }
-        </RadzenStack>
-        <RadzenStack Style="width:300px; padding: 0 10px 10px 10px;" Orientation="Orientation.Horizontal">
+        </div>
+    </Template>
+    <ChildContent>
+        <RadzenText TextStyle="TextStyle.Body2" Style="font-weight: bold;padding: 0 10px 0 10px;">@L["Your"] @AppSettings.AppName @L["version"] 🚀</RadzenText>
+        <RadzenStack Style="padding: 0 0 5px 10px;" Orientation="Orientation.Horizontal">
             <RadzenText TextStyle="TextStyle.Body2" class="rz-text-secondary-color">
                 @BuildInfo.Version
 
@@ -26,15 +24,23 @@
             </RadzenText>
         </RadzenStack>
 
+        @if (NewRelease != null)
+        {
+            <RadzenLink Style="padding: 0 0 0 10px;" Path="@NewRelease.Url" Target="_blank">
+                <RadzenBadge BadgeStyle="BadgeStyle.Info" Text="@L["Update available {0}", NewRelease.Version]" />
+                <RadzenIcon Icon="open_in_new" IconColor="@Colors.Primary" Style="font-size: 0.9rem; margin-left: 2px; vertical-align: middle;" />
+            </RadzenLink>
+        }
+
         <hr class="solid">
 
-        <RadzenProfileMenuItem Text="@L["Support"]" Icon="support_agent" Path="https://github.com/Corsinvest/cv4pve-admin/issues" Target="_blank" />
         <RadzenProfileMenuItem Text="@L["Documentation"]" Icon="menu_book" Path="https://corsinvest.github.io/cv4pve-admin/" Target="_blank" />
+        <RadzenProfileMenuItem Text="@L["Release notes"]" Icon="celebration" Value="@("release-notes")" />
+        <RadzenProfileMenuItem Text="@L["Support"]" Icon="support_agent" Path="https://github.com/Corsinvest/cv4pve-admin/issues" Target="_blank" />
 
         <hr class="solid">
 
         <RadzenProfileMenuItem Text="@L["Keyboard Shortcuts"]" Icon="keyboard" Value="@("shortcuts")" />
-        <RadzenProfileMenuItem Text="@L["Release notes"]" Icon="celebration" Value="@("release-notes")" />
 
         <hr class="solid">
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/HelpMenu.razor.cs
@@ -24,7 +24,7 @@ public partial class HelpMenu(ISettingsService settingsService,
     protected override async Task OnInitializedAsync()
     {
         AppSettings = settingsService.GetAppSettings();
-        NewRelease = await releaseService.NewReleaseIsAvailableAsync(false);
+        NewRelease = await releaseService.NewReleaseIsAvailableAsync(includePrerelease: BuildInfo.IsTesting);
         await BuildUrlsAsync();
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Monitoring/SystemInfo.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Monitoring/SystemInfo.razor.cs
@@ -21,8 +21,8 @@ public partial class SystemInfo(IReleaseService releaseService)
         var process = Process.GetCurrentProcess();
         var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
 
-        var latestRelease = await releaseService.NewReleaseIsAvailableAsync();
-        var isInContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
+        var latestRelease = await releaseService.NewReleaseIsAvailableAsync(includePrerelease: Core.BuildInfo.IsTesting);
+        var isInContainer = ApplicationHelper.IsInContainer;
 
         // Get network info
         var hostName = Dns.GetHostName();

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/ReleaseChecker/ReleaseCheckHostedService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/ReleaseChecker/ReleaseCheckHostedService.cs
@@ -55,7 +55,7 @@ public class ReleaseCheckHostedService(ILogger<ReleaseCheckHostedService> logger
         {
             logger.LogDebug("Checking for new releases");
 
-            var newRelease = await releaseService.NewReleaseIsAvailableAsync(includePrerelease: false, force: false, cancellationToken);
+            var newRelease = await releaseService.NewReleaseIsAvailableAsync(includePrerelease: Core.BuildInfo.IsTesting, force: false, cancellationToken);
 
             if (newRelease != null)
             {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/ReleaseChecker/ReleaseService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/ReleaseChecker/ReleaseService.cs
@@ -28,7 +28,9 @@ public class ReleaseService(IHttpClientFactory httpClientFactory,
             ? await DockerHubFetcher.GetReleasesAsync(httpClientFactory, logger, cancellationToken)
             : await GitHubFetcher.GetReleasesAsync(httpClientFactory, logger, cancellationToken);
 
-    public async Task<ReleaseInfo?> NewReleaseIsAvailableAsync(bool includePrerelease = false, bool force = false, CancellationToken cancellationToken = default)
+    public async Task<ReleaseInfo?> NewReleaseIsAvailableAsync(bool includePrerelease = false,
+                                                               bool force = false,
+                                                               CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{CacheKey}:{includePrerelease}";
 


### PR DESCRIPTION
## Summary
- Add red dot badge on help icon when a new release is available
- Show "Update available {version}" badge with link and `open_in_new` icon in the help menu
- Reorganize HelpMenu items order (Documentation, Release notes, Support → Keyboard Shortcuts → Report a Bug, Request a Feature, Provide Feedback)
- Use `BuildInfo.IsTesting` for `includePrerelease` in all release check calls (HelpMenu, SystemInfo, ReleaseCheckHostedService)
- Reformat `NewReleaseIsAvailableAsync` signature for readability