### PR TITLE
fix: initialize appsettings.extra.json with valid empty JSON in init container

### DIFF
--- a/src/docker/docker-compose-ce.yaml
+++ b/src/docker/docker-compose-ce.yaml
@@ -32,7 +32,7 @@ services:
     command: >
       sh -c "
         mkdir -p /app/data /app/config &&
-        touch /app/config/appsettings.extra.json &&
+        [ -f /app/config/appsettings.extra.json ] || echo '{}' > /app/config/appsettings.extra.json &&
         chown -R 1654:1654 /app/data /app/config
       "
     volumes:

--- a/src/docker/docker-compose-ee.yaml
+++ b/src/docker/docker-compose-ee.yaml
@@ -46,7 +46,7 @@ services:
     command: >
       sh -c "
         mkdir -p /app/data /app/config &&
-        touch /app/config/appsettings.extra.json &&
+        [ -f /app/config/appsettings.extra.json ] || echo '{}' > /app/config/appsettings.extra.json &&
         chown -R 1654:1654 /app/data /app/config
       "
     volumes:


### PR DESCRIPTION
## Summary

- Replace `touch /app/config/appsettings.extra.json` with `[ -f ... ] || echo '{}' > ...` in both CE and EE docker-compose init containers
- Fixes startup crash: ASP.NET Core throws `JsonReaderException` when loading an empty file via `AddJsonFile`
- The file is only created if it doesn't already exist, preserving any user configuration

## Test plan

- [ ] Fresh deploy: verify `appsettings.extra.json` is created with `{}` content
- [ ] Existing deploy: verify existing `appsettings.extra.json` is not overwritten
- [ ] App starts without `InvalidDataException` / `JsonReaderException`