### PR TITLE
fix: handle invalid appsettings.extra.json gracefully

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using System.Text.Json;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
+
+public static class ConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Adds a JSON configuration file, skipping it with a warning if the file contains invalid JSON.
+    /// Returns a warning message if the file was skipped, null otherwise.
+    /// </summary>
+    public static (IConfigurationBuilder Builder, string? Warning) AddJsonFileSafe(this IConfigurationBuilder builder, string path, bool reloadOnChange = true)
+    {
+        if (File.Exists(path))
+        {
+            try { JsonDocument.Parse(File.ReadAllText(path)); }
+            catch (JsonException ex)
+            {
+                var warning = $"'{path}' contains invalid JSON and will be ignored. Fix the file and restart. Error: {ex.Message}";
+                Console.Error.WriteLine($"WARNING: {warning}");
+                return (builder, warning);
+            }
+        }
+
+        return (builder.AddJsonFile(path, optional: true, reloadOnChange: reloadOnChange), null);
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin/Program.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddJsonFile("appsettings.extra.json", optional: true, reloadOnChange: true);
+var (_, extraSettingsWarning) = builder.Configuration.AddJsonFileSafe("appsettings.extra.json");
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceAspireDefaults();
@@ -23,6 +23,7 @@ builder.Host.UseSerilog((_, config) => config.ReadFrom.Configuration(builder.Con
 
 Log.Logger.Information("Start cv4pve-admin....");
 Log.Logger.Information("Version: {Version}", BuildInfo.Version);
+if (extraSettingsWarning != null) { Log.Logger.Warning(extraSettingsWarning); }
 
 // Add services to the container.
 builder.Services.AddRazorComponents()


### PR DESCRIPTION
## Summary
- Add `ConfigurationBuilderExtensions.AddJsonFileSafe` that validates JSON before loading `appsettings.extra.json`
- If the file contains invalid JSON, it is skipped and a warning is logged (stderr before Serilog init + Serilog after)
- Prevents startup crash when the file is empty or malformed (e.g. after manual edits)

## Test plan
- [ ] Start app with valid `appsettings.extra.json` → loads normally
- [ ] Start app with empty `appsettings.extra.json` → warning logged, app starts
- [ ] Start app with invalid JSON in `appsettings.extra.json` → warning logged, app starts
- [ ] Start app without `appsettings.extra.json` → no warning, app starts