### PR TITLE
refactor: rename "Remove All Data" to "Delete all data" in Backups and Replications

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor
@@ -35,12 +35,12 @@
 
                 <RadzenButton Variant="Variant.Text"
                               Size="ButtonSize.Small"
-                              Text="@L["Remove All Data"]"
+                              Text="@L["Delete all data"]"
                               Click="RemoveAllDataAsync"
                               Icon="delete"
                               ButtonStyle="ButtonStyle.Danger"
-                              title="@L["Remove All Data"]"
-                              aria-label="@L["Remove All Data"]" />
+                              title="@L["Delete all data"]"
+                              aria-label="@L["Delete all data"]" />
             </TemplateBefore>
 
             <TemplateAfter>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
@@ -112,7 +112,7 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
 
     private async Task RemoveAllDataAsync()
     {
-        if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Remove all data"], true))
+        if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Delete all data"], true))
         {
             await using var db = await dbContextFactory.CreateDbContextAsync();
             await db.TaskResults.DeleteAsync(ClusterName);

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor
@@ -34,12 +34,12 @@
 
                 <RadzenButton Variant="Variant.Text"
                               Size="ButtonSize.Small"
-                              Text="@L["Remove All Data"]"
+                              Text="@L["Delete all data"]"
                               Click="RemoveAllDataAsync"
                               Icon="delete"
                               ButtonStyle="ButtonStyle.Danger"
-                              title="@L["Remove All Data"]"
-                              aria-label="@L["Remove All Data"]" />
+                              title="@L["Delete all data"]"
+                              aria-label="@L["Delete all data"]" />
             </TemplateBefore>
 
             <TemplateAfter>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
@@ -75,7 +75,7 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
 
     private async Task RemoveAllDataAsync()
     {
-        if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Remove all data"], true))
+        if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Delete all data"], true))
         {
             await using var db = await dbContextFactory.CreateDbContextAsync();
             await db.JobResults.DeleteAsync(ClusterName);


### PR DESCRIPTION
## Summary
- Rename button label, title, aria-label and confirm dialog title from `"Remove All Data"` to `"Delete all data"` in `BackupAnalytics` and `ReplicationAnalytics` for consistent UX wording.