### PR TITLE
feat: CronEditor tooltip+popup UX, MarkdownEditor Placeholder/Style, InfoScheduler icon

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
@@ -8,10 +8,11 @@ namespace Corsinvest.ProxmoxVE.Admin.Core;
 
 public static class BuildInfo
 {
+    private const int TestingExpirationMonths = 1;
+
     public static readonly string Version = string.Empty;
     public static readonly string PreRelease = string.Empty;
     public static readonly bool IsTesting;
-    public const int TestingExpirationMonths = 3;
 
     public static readonly string Edition = string.Empty;
     public static readonly bool IsEnterpriseEdition;

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CronEditor.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CronEditor.razor
@@ -9,42 +9,28 @@
 <RadzenStack Orientation="Orientation.Vertical" class="rz-w-100">
     <RadzenFormField Text="@Label" AllowFloatingLabel="false" class="rz-w-100">
         <Start>
-            @if (AllowEditor)
-            {
-                <RadzenButton @ref="ButtonRef"
-                              Icon="expand_more"
-                              Click="@(args => PopupRef.ToggleAsync(ButtonRef.Element))"
-                              Size="ButtonSize.ExtraSmall"
-                              Variant="Variant.Text" />
-            }
+            <RadzenIcon Icon="schedule" />
         </Start>
         <ChildContent>
-            <RadzenTextBox Name="@Id"
+            <RadzenTextBox @ref="TextBoxRef"
+                           Name="@Id"
                            Value="@Expression"
-                           ValueChanged="@(async (string value) => { Expression = value; await UpdateAsync(); })" />
+                           ValueChanged="@(async (string value) => { Expression = value; await UpdateAsync(); })"
+                           @onclick="@ToggleAsync"
+                           MouseEnter="ShowTooltip" />
         </ChildContent>
-        <End>
-            <InfoIcon>
-                @L["Descriptor:"] - @Descriptor
-                <br />
-                @L["Next Occurrence"] - @NextOccurrence
-            </InfoIcon>
-        </End>
         <Helper>
             <RadzenCustomValidator Component="@Id" Validator="@(() => IsValid)" Text="@L["Cron syntax not valid!"]" />
         </Helper>
     </RadzenFormField>
 </RadzenStack>
 
-<Popup @ref="PopupRef" Lazy="true" Style="display: none;
-        position: absolute;
-        overflow: hidden;
-        padding: 15px;
-        border: var(--rz-panel-border);
-        background-color: var(--rz-panel-background-color);
-        box-shadow: var(--rz-panel-shadow);
-        border-radius: var(--rz-border-radius)">
-
+<Popup @ref="PopupRef"
+       Lazy="true"
+       Style="display: none; position: absolute; width: min-content;" class="rz-panel"
+       AutoFocusFirstElement="false"
+       Open="@(() => PopupIsVisible = true)"
+       Close="@(() => PopupIsVisible = false)">
     <SchedulerEditor CronExpression="@Expression"
                      CronExpressionChanged="@(async (string value) => { Expression = value; await UpdateAsync(); })" />
 
@@ -53,3 +39,17 @@
     <RadzenText TextStyle="TextStyle.Subtitle2"><strong>@L["Schedule:"]</strong> @Descriptor </RadzenText>
     <RadzenText TextStyle="TextStyle.Subtitle2"><strong>@L["Next occurrence:"]</strong> @NextOccurrence</RadzenText>
 </Popup>
+
+@code {
+    private void ShowTooltip(ElementReference elementReference)
+    {
+        if (PopupIsVisible) { return; }
+
+        TooltipService.Open(elementReference, _ =>
+            @<div>
+                    <div><strong>@L["Schedule:"]</strong> @Descriptor</div>
+                    <div><strong>@L["Next occurrence:"]</strong> @NextOccurrence</div>
+                </div>);
+
+            }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CronEditor.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CronEditor.razor.cs
@@ -6,7 +6,7 @@ using Radzen.Blazor.Rendering;
 
 namespace Corsinvest.ProxmoxVE.Admin.Core.Components;
 
-public partial class CronEditor
+public partial class CronEditor(TooltipService TooltipService)
 {
     [Parameter] public string Expression { get; set; } = default!;
     [Parameter] public EventCallback<string> ExpressionChanged { get; set; } = default!;
@@ -21,11 +21,20 @@ public partial class CronEditor
 
     private string Id { get; set; } = UniqueID!;
     private Popup PopupRef { get; set; } = default!;
-    private RadzenButton ButtonRef { get; set; } = default!;
+    private bool PopupIsVisible { get; set; } 
+    private RadzenTextBox TextBoxRef { get; set; } = default!;
 
     protected override void OnInitialized()
     {
         if (string.IsNullOrEmpty(Label)) { Label = L[" Cron Schedule"]; }
+    }
+
+    private async Task ToggleAsync()
+    {
+        if (AllowEditor)
+        {
+            await PopupRef.ToggleAsync(TextBoxRef.Element);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/InfoScheduler.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/InfoScheduler.razor
@@ -10,8 +10,13 @@
 {
     @if (JobSchedule.CronExpressionIsValid)
     {
-        <div>
-            <RadzenText Text="@($"{L["Next Execution"]} : {JobSchedule.CronNextExecution:g} - {JobSchedule.CronExpressionDescriptor}")" TextStyle="TextStyle.Caption" />
+        <div style="align-content: end">
+            <InfoIcon>
+                @* <RadzenText TextStyle="TextStyle.Caption"> *@
+                @L["Next Execution"] : @($"{JobSchedule.CronNextExecution:g}") <br />
+                @JobSchedule.CronExpressionDescriptor
+                @* </RadzenText> *@
+            </InfoIcon>
         </div>
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/MarkdownEditor.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/MarkdownEditor.razor
@@ -1,15 +1,16 @@
-@*
+﻿@*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
 *@
 @inherits AdminComponentBase
 
-<RadzenTabs>
+<RadzenTabs Style="@Style">
     <Tabs>
         <RadzenTabsItem Text="@L["Write"]" Icon="edit">
             <RadzenTextArea Value="@Value"
                             ValueChanged="@((string value) => ValueChanged.InvokeAsync(value))"
                             Rows="@Rows"
+                            Placeholder="@Placeholder"
                             class="rz-w-100" />
         </RadzenTabsItem>
 
@@ -31,4 +32,6 @@
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string> ValueChanged { get; set; }
     [Parameter] public int Rows { get; set; } = 10;
+    [Parameter] public string? Placeholder { get; set; }
+    [Parameter] public string? Style { get; set; }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Widgets/Memo/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Widgets/Memo/Render.razor
@@ -13,5 +13,5 @@
 }
 else
 {
-    <RadzenMarkdown Text="@Settings.Content" AllowHtml="true"/>
+    <RadzenMarkdown Text="@Settings.Content" AllowHtml="true" />
 }


### PR DESCRIPTION
## Summary
- **CronEditor**: replace expand button with schedule icon; click on textbox toggles popup editor; hover shows tooltip with schedule description and next occurrence (hidden when popup is open)
- **MarkdownEditor**: add `Placeholder` and `Style` parameters
- **InfoScheduler**: use `InfoIcon` component instead of inline text for next execution info
- **BuildInfo**: make `TestingExpirationMonths` private, change value from 3 to 1
- **Memo/Render.razor**: self-closing tag whitespace fix