### PR TITLE
feat: add VmJollyField and VmJollyPickerDialog, refactor AutoSnap VM selection

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyField.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyField.razor
@@ -1,0 +1,37 @@
+@*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+*@
+@inherits AdminComponentBase
+
+<RadzenFormField Text="@Label" AllowFloatingLabel="false" class="rz-w-100">
+    <Start>
+        <RadzenIcon Icon="checklist" />
+    </Start>
+    <ChildContent>
+        <RadzenTextBox Value="@Value" ReadOnly="true" Name="@Name" />
+    </ChildContent>
+    <End>
+        <RadzenButton Icon="search"
+                      Size="ButtonSize.ExtraSmall"
+                      ButtonStyle="ButtonStyle.Light"
+                      Click="OpenPickerAsync"
+                      title="@L["Select VM/CT"]" />
+    </End>
+    <Helper>
+        @if (HelperContent != null)
+        {
+            @HelperContent
+        }
+    </Helper>
+</RadzenFormField>
+
+@code
+{
+    [Parameter] public string Value { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public string ClusterName { get; set; } = string.Empty;
+    [Parameter] public string? Label { get; set; }
+    [Parameter] public string? Name { get; set; }
+    [Parameter] public RenderFragment? HelperContent { get; set; }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyField.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyField.razor.cs
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace Corsinvest.ProxmoxVE.Admin.Core.Components.ProxmoxVE.Common;
+
+public partial class VmJollyField(DialogService dialogService)
+{
+    private async Task OpenPickerAsync()
+    {
+        var ret = await dialogService.OpenSideExAsync<VmJollyPickerDialog>(L["Select VM/CT"],
+                                                                           new()
+                                                                           {
+                                                                               [nameof(VmJollyPickerDialog.ClusterName)] = ClusterName,
+                                                                               [nameof(VmJollyPickerDialog.Value)] = Value ?? string.Empty,
+                                                                           },
+                                                                           new()
+                                                                           {
+                                                                               CloseDialogOnOverlayClick = true,
+                                                                               Resizable = true,
+                                                                               Width = "900px",
+                                                                           });
+
+        if (ret is string result) { await ValueChanged.InvokeAsync(result); }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyPickerDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyPickerDialog.razor
@@ -1,0 +1,82 @@
+﻿@*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+*@
+@using Corsinvest.ProxmoxVE.Admin.Core.Components.ProxmoxVE.Cluster
+@using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster
+@inherits AdminComponentBase
+
+<RadzenStack Orientation="Orientation.Vertical" JustifyContent="JustifyContent.SpaceBetween" Style="height: 100%; overflow: hidden;">
+
+    @* Top — composer *@
+    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.End" Gap="8px" class="rz-mb-2">
+        <RadzenFormField Text="@L["Preset"]" AllowFloatingLabel="false" Style="flex: 1;">
+            <ChildContent>
+                <RadzenDropDown TValue="string"
+                                Data="@AvailableTokens"
+                                @bind-Value="@SelectedPreset"
+                                AllowFiltering="true"
+                                FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                Placeholder="@L["Select..."]" />
+            </ChildContent>
+        </RadzenFormField>
+        <RadzenButton Text="@L["Add"]" Icon="add" Size="ButtonSize.Small" Click="AddPreset" Disabled="@string.IsNullOrEmpty(SelectedPreset)" />
+
+        <RadzenFormField Text="@L["Custom"]" AllowFloatingLabel="false" Style="flex: 1;">
+            <ChildContent>
+                <RadzenTextBox @bind-Value="@CustomToken" Placeholder="@L["%name%, 100:104, -100..."]" />
+            </ChildContent>
+        </RadzenFormField>
+        <RadzenButton Text="@L["Add"]" Icon="add" Size="ButtonSize.Small" Click="AddCustom" Disabled="@string.IsNullOrEmpty(CustomToken)" />
+    </RadzenStack>
+
+    @* Middle — tokens list + preview *@
+    <RadzenRow Gap="8px" Style="flex: 1; overflow: hidden; min-height: 0;">
+        @* Left — token list *@
+        <RadzenColumn Size="3" Style="overflow-y: auto; height: 100%;">
+            <RadzenText Text="@L["Tokens"]" TextStyle="TextStyle.Subtitle2" class="rz-mb-1" />
+            @if (!Tokens.Any())
+            {
+                <RadzenText Text="@L["No tokens added"]" TextStyle="TextStyle.Caption" class="rz-color-secondary" />
+            }
+            else
+            {
+                @foreach (var token in Tokens.ToList())
+                {
+                    var t = token;
+                    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="4px" class="rz-mb-1">
+                        <RadzenText Text="@t" Style="flex: 1; font-family: monospace;" />
+                        <RadzenButton Icon="close"
+                                      Size="ButtonSize.ExtraSmall"
+                                      ButtonStyle="ButtonStyle.Danger"
+                                      Variant="Variant.Text"
+                                      Click="@(() => RemoveToken(t))" />
+                    </RadzenStack>
+                }
+            }
+        </RadzenColumn>
+
+        @* Right — preview *@
+        <RadzenColumn Size="9" Style="overflow: hidden; height: 100%;">
+            <RadzenText Text="@L["Preview"]" TextStyle="TextStyle.Subtitle2" class="rz-mb-1" />
+            <ResourcesEx @ref="ResourcesExRef"
+                         ClusterNames="@([ClusterName])"
+                         FilterExpression="@FilterPreview"
+                         ResourceType="ClusterResourceType.Vm"
+                         PropertyIconStatus="ResourcesExPropertyIconStatus.Status"
+                         IconStatus="ResourceColumnIconStatus.IconAndText"
+                         UseProgressBarPercentage="false"
+                         DescriptionAsLink="false"
+                         AvailableCommands="false"
+                         ShowSnapshotSize="false"
+                         ShowSearchBox="false"
+                         ShowLoading="true"
+                         @bind-DataGridSettings="DataGridSettings" />
+        </RadzenColumn>
+    </RadzenRow>
+
+    @* Bottom — select button *@
+    <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Style="flex-shrink: 0;">
+        <RadzenButton Text="@L["Select"]" Click="OnSelect" Style="width: fit-content;" Size="ButtonSize.Small" />
+    </RadzenStack>
+</RadzenStack>

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyPickerDialog.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/VmJollyPickerDialog.razor.cs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using Corsinvest.ProxmoxVE.Admin.Core.Components.ProxmoxVE.Cluster;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Components.ProxmoxVE.Common;
+
+public partial class VmJollyPickerDialog(IAdminService adminService, DialogService dialogService)
+{
+    [Parameter] public string ClusterName { get; set; } = string.Empty;
+    [Parameter] public string Value { get; set; } = string.Empty;
+
+    private ResourcesEx? ResourcesExRef { get; set; }
+    private HashSet<long> PreviewVmIds { get; set; } = [];
+    private DataGridSettings DataGridSettings { get; set; } = new();
+    private List<string> Tokens { get; set; } = [];
+    private List<string> AvailableTokens { get; set; } = [];
+    private string? SelectedPreset { get; set; }
+    private string CustomToken { get; set; } = string.Empty;
+
+    protected override void OnInitialized()
+        => RadzenHelper.MakeDataGridSettings(DataGridSettings,
+                                             [nameof(ClusterResourceEx.Status),
+                                              nameof(ClusterResourceEx.Type),
+                                              nameof(ClusterResourceEx.Node),
+                                              nameof(ClusterResourceEx.Description)]);
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Parse input value into tokens
+        if (!string.IsNullOrWhiteSpace(Value))
+        {
+            Tokens = [.. Value.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim())];
+        }
+
+        // Load available tokens for autocomplete
+        var client = await adminService[ClusterName].GetPveClientAsync();
+        AvailableTokens = [.. await client.GetVmIdsAsync(true, true, true, true, true, true)];
+
+        await RefreshPreviewAsync();
+    }
+
+    private async Task AddPreset()
+    {
+        if (string.IsNullOrEmpty(SelectedPreset)) { return; }
+        if (!Tokens.Contains(SelectedPreset))
+        {
+            Tokens.Add(SelectedPreset);
+            await RefreshPreviewAsync();
+        }
+        SelectedPreset = null;
+    }
+
+    private async Task AddCustom()
+    {
+        var token = CustomToken.Trim();
+        if (string.IsNullOrEmpty(token)) { return; }
+        if (!Tokens.Contains(token))
+        {
+            Tokens.Add(token);
+            await RefreshPreviewAsync();
+        }
+        CustomToken = string.Empty;
+    }
+
+    private async Task RemoveToken(string token)
+    {
+        Tokens.Remove(token);
+        await RefreshPreviewAsync();
+    }
+
+    private async Task RefreshPreviewAsync()
+    {
+        if (Tokens.Count == 0)
+        {
+            PreviewVmIds = [];
+            await InvokeAsync(StateHasChanged);
+        }
+
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var client = await adminService[ClusterName].GetPveClientAsync();
+            var jolly = string.Join(",", Tokens);
+            var vms = await client.GetVmsAsync(jolly);
+            PreviewVmIds = [.. vms.Select(v => v.VmId)];
+        }
+        finally
+        {
+            await InvokeAsync(StateHasChanged);
+            if (ResourcesExRef != null) { await ResourcesExRef.RefreshDataAsync(); }
+        }
+    }
+
+    private bool FilterPreview(ClusterResourceEx item, string _) => PreviewVmIds.Contains(item.VmId);
+
+    private void OnSelect() => dialogService.Close(string.Join(",", Tokens));
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
@@ -83,7 +83,7 @@ public static class RadzenUIExtensions
                                                               Resizable = true,
                                                           });
 
-    public static async Task<dynamic> OpenSideExAsync<T>(this DialogService dialogService,
+    public static async Task<dynamic?> OpenSideExAsync<T>(this DialogService dialogService,
                                                          string title,
                                                          Dictionary<string, object> parameters,
                                                          DialogOptions options)
@@ -100,7 +100,7 @@ public static class RadzenUIExtensions
         return await dialogService.OpenAsync<T>(title, parameters!, options);
     }
 
-    public static async Task<dynamic> OpenSideEditAsync<TDialog>(this DialogService dialogService,
+    public static async Task<dynamic?> OpenSideEditAsync<TDialog>(this DialogService dialogService,
                                                                  string title,
                                                                  bool isNew,
                                                                  object model,

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/JobDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/JobDialog.razor
@@ -16,21 +16,15 @@
 
                 <SwitchField @bind-Value="@Model.Enabled"
                              Label="@L["Enabled"]"
-                             Name="@nameof(Model.Enabled)"
-                             IconOn="play_circle"
-                             IconOff="pause_circle" />
+                             Name="@nameof(Model.Enabled)" />
 
                 <SwitchField @bind-Value="@Model.VmStatus"
                              Label="@L["Include RAM"]"
-                             Name="@nameof(Model.VmStatus)"
-                             IconOn="memory"
-                             IconOff="memory" />
+                             Name="@nameof(Model.VmStatus)" />
 
                 <SwitchField @bind-Value="@Model.OnlyRuns"
                              Label="@L["While VM/CT Running"]"
-                             Name="@nameof(Model.OnlyRuns)"
-                             IconOn="play_circle"
-                             IconOff="stop_circle" />
+                             Name="@nameof(Model.OnlyRuns)" />
 
                 <RadzenFormField Text="@L["Label"]" AllowFloatingLabel="false">
                     <Start>
@@ -49,7 +43,7 @@
                         <RadzenIcon Icon="history" />
                     </Start>
                     <ChildContent>
-                        <RadzenNumeric Name="@nameof(Model.Keep)" @bind-Value="@Model.Keep" />
+                        <RadzenNumeric Name="@nameof(Model.Keep)" @bind-Value="@Model.Keep" Min="1" />
                     </ChildContent>
                     <Helper>
                         <RadzenDataAnnotationValidator Component="@nameof(Model.Keep)" />
@@ -70,20 +64,14 @@
 
                 <CronEditor @bind-Expression="@Model.CronExpression" AllowEditor="true" />
 
-                <RadzenFormField Text="@L["Vm Ids"]" AllowFloatingLabel="false">
-                    <Start>
-                        <RadzenIcon Icon="checklist" />
-                    </Start>
-                    <ChildContent>
-                        <RadzenDropDown @bind-Value="@Model.VmIdsList" Data="VmIds" Name="@nameof(Model.VmIdsList)"
-                                        Multiple="true" AllowClear="true" AllowFiltering="true" MaxSelectedLabels="99"
-                                        SearchTextChanged="SearchTextChanged" Chips="true" />
-                    </ChildContent>
-                    <Helper>
-                        <RadzenCustomValidator Component="@nameof(Model.VmIdsList)"
-                                               Validator="@(() => (Model.VmIdsList?.Count() ?? 0) > 0)" Text="@L["Select VM/CT id!"]" />
-                    </Helper>
-                </RadzenFormField>
+                <VmJollyField @bind-Value="@Model.VmIds"
+                              ClusterName="@Model.ClusterName"
+                              Label="@L["Vm Ids"]"
+                              Name="@nameof(Model.VmIds)">
+                    <HelperContent>
+                        <RadzenRequiredValidator Component="@nameof(Model.VmIds)" Text="@L["Select VM/CT id!"]" />
+                    </HelperContent>
+                </VmJollyField>
             </RadzenStack>
         </RadzenTabsItem>
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/JobDialog.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/JobDialog.razor.cs
@@ -6,48 +6,12 @@ using Corsinvest.ProxmoxVE.Admin.Core.Modularity;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Components;
 
-public partial class JobDialog(IAdminService adminService,
-                               IModuleService moduleService) : IModelParameter<JobSchedule>
+public partial class JobDialog(IModuleService moduleService) : IModelParameter<JobSchedule>
 {
     [Parameter] public JobSchedule Model { get; set; } = default!;
 
-    private ICollection<string> VmIds { get; set; } = [];
     private Type? WebHookTabComponentType { get; set; } = default!;
 
-    private IEnumerable<string> _vmIdsBase = [];
-
-    protected override async Task OnInitializedAsync()
-    {
-        var client = await adminService[Model.ClusterName].GetPveClientAsync();
-
-        _vmIdsBase = [.. await client.GetVmIdsAsync(true,
-                                                    true,
-                                                    true,
-                                                    true,
-                                                    true,
-                                                    true)];
-
-        MakeVmIds();
-
-        WebHookTabComponentType = moduleService.Get<Module>()!.WebHookTabComponentType;
-    }
-
-    private void MakeVmIds()
-        => VmIds = [.. new List<string>([.. _vmIdsBase, .. Model.VmIdsList])
-                        .Distinct()
-                        .Order()];
-
-    private void SearchTextChanged(string value)
-    {
-        if (!string.IsNullOrEmpty(value) || !string.IsNullOrWhiteSpace(value))
-        {
-            var data = VmIds.Where(a => a.Contains(value));
-            if (!data.Any())
-            {
-                MakeVmIds();
-                VmIds.Add(value);
-                VmIds = [.. VmIds.Distinct().Order()];
-            }
-        }
-    }
+    protected override void OnInitialized()
+        => WebHookTabComponentType = moduleService.Get<Module>()!.WebHookTabComponentType;
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
@@ -47,7 +47,7 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
                                                          {
                                                              Id = a.Id,
                                                              Enabled = a.Enabled,
-                                                             VmIdsList = a.VmIdsList,
+                                                             VmIds = a.VmIds,
                                                              Label = a.Label,
                                                              Description = a.Description,
                                                              Keep = a.Keep,

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/RenderSettings.razor
@@ -7,9 +7,7 @@
 
 <SwitchField @bind-Value="@Model.Enabled"
              Label="@L["Enabled"]"
-             Name="@nameof(Model.Enabled)"
-             IconOn="play_circle"
-             IconOff="pause_circle" />
+             Name="@nameof(Model.Enabled)" />
 
 <RadzenFormField Text="@L["Search Mode"]" AllowFloatingLabel="false" class="rz-w-100">
     <Start>
@@ -44,7 +42,7 @@
         <RadzenIcon Icon="layers" />
     </Start>
     <ChildContent>
-        <RadzenNumeric Name="@nameof(Model.KeepHistory)" @bind-Value="@Model.KeepHistory" />
+        <RadzenNumeric Name="@nameof(Model.KeepHistory)" @bind-Value="@Model.KeepHistory" Min="0" />
     </ChildContent>
     <Helper>
         <RadzenDataAnnotationValidator Component="@nameof(Model.KeepHistory)" />
@@ -56,7 +54,7 @@
         <RadzenIcon Icon="percent" />
     </Start>
     <ChildContent>
-        <RadzenNumeric Name="@nameof(Model.MaxPercentageStorage)" @bind-Value="@Model.MaxPercentageStorage" />
+        <RadzenNumeric Name="@nameof(Model.MaxPercentageStorage)" @bind-Value="@Model.MaxPercentageStorage" Min="0" Max="100" />
     </ChildContent>
     <Helper>
         <RadzenDataAnnotationValidator Component="@nameof(Model.MaxPercentageStorage)" />
@@ -65,9 +63,7 @@
 
 <SwitchField @bind-Value="@Model.OnRemoveJobRemoveSnapshots"
              Label="@L["On remove job remove snapshots in Proxmox VE"]"
-             Name="@nameof(Model.OnRemoveJobRemoveSnapshots)"
-             IconOn="delete_sweep"
-             IconOff="delete_sweep" />
+             Name="@nameof(Model.OnRemoveJobRemoveSnapshots)" />
 
 <RadzenFormField Text="@L["Notify"]" AllowFloatingLabel="false" class="rz-w-100">
     <Start>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/GlobalUsings.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/GlobalUsings.cs
@@ -10,7 +10,6 @@ global using Corsinvest.ProxmoxVE.Admin.Core.Services;
 global using Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Helpers;
 global using Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Models;
 global using Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Persistence;
-global using Corsinvest.ProxmoxVE.Api.Extension;
 global using Microsoft.AspNetCore.Components;
 global using Microsoft.AspNetCore.Components.Web;
 global using Microsoft.EntityFrameworkCore;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Helpers/ActionHelper.cs
@@ -41,7 +41,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                             $"Job ID: {id}" +
                                             $", Cluster: {job.ClusterName}, " +
                                             $"Label: {job.Label}, " +
-                                            $"VMs: {job.VmIdsList.JoinAsString(",")}");
+                                            $"VMs: {job.VmIds}");
             }
             await db.Jobs.DeleteAsync(id);
             await PublishDataChangedAsync(scope);
@@ -72,7 +72,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 await using var log = new StringWriterEvent();
                 var app = GetApp(client, scope.GetLoggerFactory(), log);
 
-                await app.CleanAsync(job.VmIdsList.JoinAsString(","),
+                await app.CleanAsync(job.VmIds,
                                      job.Label,
                                      0,
                                      job.TimeoutSnapshot * 1000,
@@ -93,7 +93,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                             $"Job ID: {id}, " +
                                             $"Cluster: {job.ClusterName}, " +
                                             $"Label: {job.Label}, " +
-                                            $"VMs: {job.VmIdsList.Count()}");
+                                            $"VMs: {job.VmIds.Split(',').Length}");
             }
 
             await PublishDataChangedAsync(scope);
@@ -166,7 +166,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
                 using (logger.LogTimeOperation(LogLevel.Debug, true, "Execution physical Snap"))
                 {
-                    var retSnap = await app.SnapAsync(job.VmIdsList.JoinAsString(","),
+                    var retSnap = await app.SnapAsync(job.VmIds,
                                                       job.Label,
                                                       job.Keep,
                                                       job.VmStatus,
@@ -222,7 +222,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                             $"Job ID: {id}, " +
                                             $"Cluster: {job.ClusterName}, " +
                                             $"Label: {job.Label}, " +
-                                            $"VMs: {job.VmIdsList.Count()}, " +
+                                            $"VMs: {job.VmIds.Split(',').Length}, " +
                                             $"Snap: {result.SnapName}, " +
                                             $"Duration: {result.Duration:hh':'mm':'ss}");
 
@@ -289,34 +289,4 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
         await PublishDataChangedAsync(scope);
     }
-
-    //public static async Task<(int scheduled, DateTime? last, int snapCount, int vmsScheduled, int inError)>
-    //    InfoAsync(IServiceScopeFactory ServiceScopeFactory, string clusterName)
-    //{
-    //    using var scope = ServiceScopeFactory.CreateScope();
-    //    var client = await scope.GetPveClientAsync(clusterName);
-    //    var jobRepo = scope.GetReadRepository<AutoSnapJob>();
-    //    var jobHistoryRepo = scope.GetReadRepository<AutoSnapJobHistory>();
-    //    var moduleClusterOptions = GetModuleClusterOptions(scope, clusterName);
-    //    var loggerFactory = scope.GetLoggerFactory();
-
-    //    var vmIdsOrNames = await GetVmIdsOrNamesAsync(jobRepo, clusterName, true);
-    //    var vmsCount = string.IsNullOrWhiteSpace(vmIdsOrNames) ?
-    //                    0 :
-    //                    (await client.GetVmsAsync(vmIdsOrNames)).Where(a => !a.IsUnknown).Count();
-
-    //    var snapCount = moduleClusterOptions.SearchMode == SearchMode.Managed
-    //                        ? vmsCount
-    //                        : (await GetApp(client, loggerFactory, null!)
-    //                                .StatusAsync(AllVms, null, moduleClusterOptions.TimestampFormat))
-    //                                .Count;
-
-    //    var specJob = new AutoSnapJobSpec(clusterName).Enabled();
-    //    var jobCount = await jobRepo.CountAsync(specJob);
-
-    //    var spec = new AutoSnapJobHistorySpec(clusterName);
-    //    var start = (await jobHistoryRepo.FirstOrDefaultAsync(spec))?.Start;
-    //    var inError = await jobHistoryRepo.CountAsync(spec.InError(7));
-    //    return (jobCount, start, snapCount, vmsCount, inError);
-    //}
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Models/JobSchedule.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Models/JobSchedule.cs
@@ -17,26 +17,13 @@ public class JobSchedule : JobScheduleBase, IClusterName, IId, IDescription
     [Required] public string Description { get; set; } = default!;
     [Required] public string VmIds { get; set; } = default!;
 
-    [NotMapped]
-    public IEnumerable<string> VmIdsList
-    {
-        get => string.IsNullOrEmpty(VmIds)
-                ? []
-                : VmIds.Split(",").AsEnumerable();
-
-        set => VmIds = (value ?? []).Order().JoinAsString(",");
-    }
-
     [Required, RegularExpression("^[a-zA-Z0-9]+$")]
     public string Label { get; set; } = default!;
 
     [Range(1, 100)]
     public int Keep { get; set; }
 
-    [Display(Name = "Include RAM")]
     public bool VmStatus { get; set; }
-
-    [Display(Name = "While VM/CT Running")]
     public bool OnlyRuns { get; set; }
 
     public long TimeoutSnapshot { get; set; } = 30;


### PR DESCRIPTION
## Summary
- Add `VmJollyField`: reusable component with readonly textbox + picker button for VM jolly string input
- Add `VmJollyPickerDialog`: token composer with preset autocomplete, free-text input, token list and live VM preview via `ResourcesEx`
- Replace inline VM selection in AutoSnap `JobDialog` with `VmJollyField`
- Remove `VmIdsList` from `JobSchedule`, use `VmIds` string directly throughout AutoSnap
- Fix `DialogService.OpenSideExAsync` return type to `Task<dynamic?>` (Radzen breaking change)