### PR TITLE
fix: core improvements and minor fixes

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.1" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.1.1" />
   </ItemGroup>
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/ActiveTasksPanel.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/ActiveTasksPanel.razor
@@ -22,7 +22,7 @@
     {
         <RadzenStack AlignItems="AlignItems.Center" JustifyContent="JustifyContent.Center" Style="padding: 16px 0;">
             <RadzenImage Path="images/misc/empty-box.png" Style="height:40px; opacity:0.5;" />
-            <RadzenText Text="@L[" tasks"]" TextStyle="TextStyle.Caption" class="rz-text-secondary-color" />
+            <RadzenText Text="@L["no tasks found"]" TextStyle="TextStyle.Caption" class="rz-text-secondary-color" />
         </RadzenStack>
     }
     else
@@ -40,6 +40,6 @@
     <hr style="margin: 4px 0 0 0;" />
 
     <RadzenStack Style="padding: 6px 12px 4px 12px;" @onclick="ViewAll">
-        <RadzenLink Text="@L["View all tasks"]" Icon="open_in_new" Style="font-size: 0.85rem;" />
+        <RadzenLink Text="@L["View all tasks"]" Style="font-size: 0.85rem;" />
     </RadzenStack>
 </RadzenPanel>

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Vm/Config.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Vm/Config.razor.cs
@@ -18,7 +18,7 @@ public partial class Config(IAdminService adminService) : IRefreshableData, IClu
 
     public async Task RefreshDataAsync()
     {
-        VmConfig = await adminService[ClusterName].CachedData.GetVmConfigAsync(Vm.Node, Vm.VmType, Vm.VmId, false);
+        VmConfig = await adminService[ClusterName].CachedData.GetGuestConfigAsync(Vm.Node, Vm.VmType, Vm.VmId, false);
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/PveAdminUIHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/PveAdminUIHelper.cs
@@ -81,6 +81,7 @@ public static class PveAdminUIHelper
         public static string Memory { get; } = "memory";
         public static string Storage { get; } = "storage";
         public static string Network { get; } = "lan";
+        public static string Disks { get; } = "database";
         public static string Node { get; } = "domain";
         public static string Vm { get; } = "desktop_windows";
         public static string Snapshot { get; } = "photo_camera";

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Search/Providers/PveSearchProvider.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Search/Providers/PveSearchProvider.cs
@@ -202,7 +202,7 @@ public class PveSearchProvider : ISearchProvider
                         }
                         else if (item.VmType == VmType.Lxc)
                         {
-                            var config = await clusterClient.CachedData.GetVmConfigAsync(item.Node, item.VmType, item.VmId, false);
+                            var config = await clusterClient.CachedData.GetGuestConfigAsync(item.Node, item.VmType, item.VmId, false);
                             item.IpAddresses = config.Networks
                                                      .Select(a => a.IpAddress)
                                                      .Where(ip => !ip.Contains(':') && ip != "127.0.0.1")

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+using System.Net;
 using BlazorDownloadFile;
 using Corsinvest.ProxmoxVE.Admin.Core.Clients.Pve;
 using Corsinvest.ProxmoxVE.Admin.Core.Commands;
@@ -75,14 +76,19 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPveClientFactory, PveClientFactory>();
 
         services.AddHttpClient("HttpStrict")
-            .ConfigureHttpClient(client => client.DefaultRequestHeaders.Add("User-Agent", "cv4pve-admin"));
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                })
+                .ConfigureHttpClient(client => client.DefaultRequestHeaders.Add("User-Agent", "cv4pve-admin"));
 
         services.AddHttpClient("HttpIgnoreCert")
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            })
-            .ConfigureHttpClient(client => client.DefaultRequestHeaders.Add("User-Agent", "cv4pve-admin"));
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                })
+                .ConfigureHttpClient(client => client.DefaultRequestHeaders.Add("User-Agent", "cv4pve-admin"));
 
         return services;
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Services/ClusterCachedData.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Services/ClusterCachedData.cs
@@ -123,7 +123,7 @@ public class ClusterCachedData
 
                                    return new VmQemuAgentNetworkGetInterfaces();
                                },
-                               60 * 30,
+                               60 * 15,
                                forceReload);
 
     private class DummyClusterResourceVmOsInfo : IClusterResourceVmOsInfo
@@ -187,7 +187,7 @@ public class ClusterCachedData
                                60,
                                forceReload);
 
-    public async Task<VmConfig> GetVmConfigAsync(string node, VmType vmType, long vmId, bool forceReload)
+    public async Task<VmConfig> GetGuestConfigAsync(string node, VmType vmType, long vmId, bool forceReload)
         => vmType switch
         {
             VmType.Qemu => await GetQemuConfigAsync(node, vmId, forceReload),

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
@@ -88,7 +88,7 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
     private async Task ShowLogAsync(Data item, bool forJob)
     {
         var title = forJob
-                ? L["Full Task"] // oppure L["Full Task {0}", taskId]
+                ? L["Full Task"] // L["Full Task {0}", item.TaskId]
                 : L["Job Vm: {0}", item.VmId!];
 
         await using var db = await dbContextFactory.CreateDbContextAsync();

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/UnprotectedDisks.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/UnprotectedDisks.razor.cs
@@ -38,7 +38,7 @@ public partial class UnprotectedDisks(IAdminService adminService) : IClusterName
 
         foreach (var item in vms)
         {
-            var config = await clusterClient.CachedData.GetVmConfigAsync(item.Node, item.VmType, item.VmId, false);
+            var config = await clusterClient.CachedData.GetGuestConfigAsync(item.Node, item.VmType, item.VmId, false);
             var disks = config.Disks.Where(a => !a.Backup);
             if (disks.Any())
             {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Widgets/Info.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Widgets/Info.cs
@@ -102,7 +102,7 @@ public class Info(IAdminService adminService,
 
             foreach (var vm in vms)
             {
-                var config = await clusterClient.CachedData.GetVmConfigAsync(vm.Node, vm.VmType, vm.VmId, false);
+                var config = await clusterClient.CachedData.GetGuestConfigAsync(vm.Node, vm.VmType, vm.VmId, false);
                 if (config?.Disks.Any(a => !a.Backup) == true) { vmsWithUnprotectedDisks++; }
             }
         }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
@@ -17,23 +17,6 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
     private static readonly string[] _sizes = ["KIB", "MIB", "GIB", "TIB"];
 
-    // TODO: when Corsinvest.ProxmoxVE.Api.Shared NuGet is updated, delete ParseLog and use ParseLogNew instead.
-    //public static List<JobResult> ParseLogNew(TaskResult job)
-    //    => BackupHelper.ParseVzdumpLog(job.Logs!)
-    //                   .Select(r => new JobResult
-    //                   {
-    //                       TaskResult   = job,
-    //                       VmId         = r.VmId,
-    //                       Start        = r.Start,
-    //                       End          = r.End,
-    //                       Size         = r.Size,
-    //                       TransferSize = r.TransferSize,
-    //                       Status       = r.Status,
-    //                       Error        = r.Error,
-    //                       Archive      = r.Archive,
-    //                   })
-    //                   .ToList();
-
     public static List<JobResult> ParseLog(TaskResult job)
     {
         const string KEY_STARTING = "INFO: Starting Backup of VM ";


### PR DESCRIPTION
## Summary
- Rename `GetVmConfigAsync` → `GetGuestConfigAsync` in `ClusterCachedData` and update all call sites (`Config.razor.cs`, `PveSearchProvider`, `BackupAnalytics` ×3)
- Add GZip/Deflate automatic decompression to `HttpStrict` and `HttpIgnoreCert` HTTP clients
- Fix `ActiveTasksPanel`: correct empty-state text key (`"no tasks found"`), remove stray `Icon` prop from `RadzenLink`
- Add `Icons.Disks` constant to `PveAdminUIHelper`
- Reduce QemuAgent network interface cache TTL from 30 → 15 minutes
- Remove stale TODO comment in `BackupAnalytics/ActionHelper.cs`
- Bump Aspire packages to 13.2.2

## Test plan
- [ ] Verify VM config still loads correctly in Resources and BackupAnalytics
- [ ] Verify ActiveTasksPanel shows correct empty-state message
- [ ] Verify HTTP responses use compression where available