### PR TITLE
fix(docker): disable broken healthcheck on cv4pve-admin container (#282)

### DIFF
--- a/src/docker/docker-compose-ce.yaml
+++ b/src/docker/docker-compose-ce.yaml
@@ -62,12 +62,15 @@ services:
         condition: service_completed_successfully
       postgres:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 45s
+    # Healthcheck disabled: the runtime image ships neither wget nor curl.
+    # See https://github.com/Corsinvest/cv4pve-admin/issues/282
+    # TODO: add curl to the Dockerfile (or ship a minimal health-check binary), then re-enable.
+    # healthcheck:
+    #   test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
+    #   interval: 30s
+    #   timeout: 10s
+    #   retries: 3
+    #   start_period: 45s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/src/docker/docker-compose-ee.yaml
+++ b/src/docker/docker-compose-ee.yaml
@@ -79,12 +79,15 @@ services:
         condition: service_healthy
       apprise:
         condition: service_started
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 45s
+    # Healthcheck disabled: the runtime image ships neither wget nor curl.
+    # See https://github.com/Corsinvest/cv4pve-admin/issues/282
+    # TODO: add curl to the Dockerfile (or ship a minimal health-check binary), then re-enable.
+    # healthcheck:
+    #   test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
+    #   interval: 30s
+    #   timeout: 10s
+    #   retries: 3
+    #   start_period: 45s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 


### PR DESCRIPTION
## Summary
Fixes #282.

The runtime image ships neither `wget` nor `curl`, so the previous healthcheck always failed — the container was marked `unhealthy` even when the web UI was fully up.

Comment out the healthcheck on both CE and EE compose files and add a TODO pointing to the root-cause fix (add `curl` to the Dockerfile, or ship a minimal health-check binary, then re-enable).

## Test plan
- [ ] `docker compose -f docker-compose-ce.yaml up -d` starts the stack without `unhealthy` status
- [ ] `docker compose -f docker-compose-ee.yaml up -d` starts the stack without `unhealthy` status
- [ ] Web UI reachable on `${CV4PVE_ADMIN_PORT}`