### PR TITLE
feat(node-protect): track folder backup in TaskTracker + update default paths

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Helpers/FolderHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Helpers/FolderHelper.cs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth;
+using Corsinvest.ProxmoxVE.Admin.Core.TaskTracking;
 using Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Persistence;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.NodeProtect.Api;
@@ -42,9 +43,13 @@ internal static class FolderHelper
         var loggerFactory = scope.GetLoggerFactory();
         var logger = loggerFactory.CreateLogger(typeof(FolderHelper));
         var auditService = scope.GetRequiredService<IAuditService>();
+        var taskTracker = scope.GetRequiredService<ITaskTrackerService>();
+        var moduleName = new Module().Name;
         await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
         var clusterClient = scope.GetClusterClient(clusterName);
         var engine = new ProtectEngine(loggerFactory.CreateLogger<ProtectEngine>());
+
+        await using var taskScope = await taskTracker.StartAsync($"NodeProtect Folder [{clusterName}]", clusterName, moduleName, clusterName);
 
         using (logger.LogTimeOperation(LogLevel.Information, true, "NodeProtect: backup data to folder for cluster '{clusterName}'", clusterName))
         {
@@ -72,11 +77,13 @@ internal static class FolderHelper
                     {
                         logs = await engine.BackupNodeAsync(node.Node, connectionInfo, paths, targetFile);
                         nodeStatus = true;
+                        taskScope.Log(logs);
                     }
                     catch (Exception ex)
                     {
                         logger.LogError(ex, "Backup failed for node {Node}", node.Node);
                         logs = ex.Message;
+                        taskScope.Log($"[{node.Node}] {ex.Message}", LogLevel.Error);
                     }
 
                     await db.FolderTaskResults.AddAsync(new()
@@ -115,6 +122,8 @@ internal static class FolderHelper
             {
                 success = false;
                 logger.LogError(ex, "Backup failed for cluster {ClusterName}", clusterName);
+                taskScope.Item.Status = TaskItemStatus.Failed;
+                taskScope.Log(ex.ToString(), LogLevel.Error);
                 throw;
             }
             finally

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Settings.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Settings.cs
@@ -19,11 +19,10 @@ public class Settings : JobScheduleBase, IModuleSettings
 /etc/.
 /var/lib/pve-cluster/.
 /var/lib/ceph/.
+/var/spool/cron/crontabs
 /root/.ssh
 /root/scripts
 /root/backup
-/root/*.sh
-/root/*.conf
 /root/.bashrc
 /root/.profile";
 


### PR DESCRIPTION
## Summary
- ` FolderHelper.BackupAsync ` now starts a task via ` ITaskTrackerService `, so each execution shows up in the **System → Tasks** page — aligned with AutoSnap, SystemReport, Diagnostic
- Per-node backup summary and errors are logged to the task scope; status is marked ` Failed ` on exception
- Updated ` Settings.PathsToBackup ` defaults: removed glob entries that ` tar ` cannot expand when paths are quoted (e.g. ` /root/*.sh `), added ` /var/spool/cron/crontabs ` (per-user cron jobs, not in ` /etc/ `)

## Test plan
- [ ] Run a scheduled / on-demand folder backup — it appears in System → Tasks with per-node log lines
- [ ] Force a failure (e.g. SSH creds wrong) — task status becomes ` Failed ` and stack trace is logged
- [ ] Fresh install: default paths are archived correctly (missing ones are skipped silently via ` --ignore-failed-read ` in node-protect 2.1.1)