### PR TITLE
feat(identity): add email confirmation flow for new users

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/MainLayout.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/MainLayout.razor.cs
@@ -63,7 +63,7 @@ public partial class MainLayout : IDisposable, IAsyncDisposable
             CurrentClusterService.ClusterName = ClusterName;
 
             var user = await CurrentUserService.GetUserAsync();
-            if (user != null && await UserManager.CheckPasswordAsync(user, ApplicationHelper.DefaultAdminPassword))
+            if (user != null && await UserManager.CheckPasswordAsync(user, ApplicationHelper.DefaultUserPassword))
             {
                 NotifyDefaultPassword();
             }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/IdentityExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/IdentityExtensions.cs
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth.Permissions;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Identity;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
 
@@ -157,8 +160,8 @@ public static class IdentityExtensions
     }
 
     public static async Task<IdentityResult> DeleteExAsync(this UserManager<ApplicationUser> userManager,
-                                                            ApplicationUser user,
-                                                            IPermissionService permissionService)
+                                                           ApplicationUser user,
+                                                           IPermissionService permissionService)
     {
         // Delete all user permissions
         var permissions = await permissionService.GetUserPermissionsAsync(user.Id);
@@ -214,4 +217,40 @@ public static class IdentityExtensions
     //    var rolesIndDb = await userManager.GetRolesAsync(user);
     //    return await userManager.RemoveFromRolesAsync(user, roles.Where(a => rolesIndDb.Contains(a)));
     //}
+
+    public static async Task<string> GeneratePasswordResetLinkAsync(this UserManager<ApplicationUser> userManager,
+                                                                    ApplicationUser user,
+                                                                    NavigationManager navigationManager)
+    {
+        var code = await userManager.GeneratePasswordResetTokenAsync(user);
+        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+        return navigationManager.GetUriWithQueryParameters(navigationManager.ToAbsoluteUri("/ResetPassword").AbsoluteUri,
+                                                           new Dictionary<string, object?> { ["code"] = code });
+    }
+
+    public static async Task SendPasswordResetAsync(this UserManager<ApplicationUser> userManager,
+                                                    ApplicationUser user,
+                                                    NavigationManager navigationManager,
+                                                    IEmailSender<ApplicationUser> emailSender)
+    {
+        var link = await userManager.GeneratePasswordResetLinkAsync(user, navigationManager);
+        await emailSender.SendPasswordResetLinkAsync(user, user.Email!, link);
+    }
+
+    public static string GenerateRandomPassword()
+        => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)) + "Aa1!";
+
+    public static async Task SendConfirmationAsync(this UserManager<ApplicationUser> userManager,
+                                                   ApplicationUser user,
+                                                   NavigationManager navigationManager,
+                                                   IEmailSender<ApplicationUser> emailSender)
+    {
+        var userId = await userManager.GetUserIdAsync(user);
+        var code = await userManager.GenerateEmailConfirmationTokenAsync(user);
+        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+        var link = navigationManager.GetUriWithQueryParameters(
+            navigationManager.ToAbsoluteUri("/ConfirmEmail").AbsoluteUri,
+            new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
+        await emailSender.SendConfirmationLinkAsync(user, user.Email!, link);
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/ApplicationHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/ApplicationHelper.cs
@@ -33,7 +33,7 @@ public static partial class ApplicationHelper
     public static string[] SupportedCultures => [DefaultCulture];
 
     public const string DefaultAdminUsername = "admin@local";
-    public const string DefaultAdminPassword = "Password123!";
+    public const string DefaultUserPassword = "Password123!";
 
     public static bool IsRunningInEfTool
         => AppDomain.CurrentDomain.FriendlyName?.Contains("ef", StringComparison.OrdinalIgnoreCase) is true

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/ForgotPassword.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/ForgotPassword.razor.cs
@@ -2,9 +2,6 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-using System.Text;
-using System.Text.Encodings.Web;
-using Microsoft.AspNetCore.WebUtilities;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.System.Security.Components.Account.Login;
 
@@ -32,12 +29,7 @@ public partial class ForgotPassword(UserManager<ApplicationUser> userManager,
             return;
         }
 
-        var code = await userManager.GeneratePasswordResetTokenAsync(user!);
-        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-        var callbackUrl = navigationManager.GetUriWithQueryParameters(navigationManager.ToAbsoluteUri("/ResetPassword").AbsoluteUri,
-                                                                      new Dictionary<string, object?> { ["code"] = code });
-
-        await EmailSender.SendPasswordResetLinkAsync(user!, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
+        await userManager.SendPasswordResetAsync(user!, navigationManager, EmailSender);
 
         IsBusy = false;
         navigationManager.NavigateTo("/ForgotPasswordConfirmation");

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/ResetPasswordConfirmation.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/ResetPasswordConfirmation.razor
@@ -11,7 +11,7 @@
 <RadzenAlert Shade="Shade.Lighter"
              Variant="Variant.Flat"
              Size="AlertSize.Small"
-             AlertStyle="AlertStyle.Warning"
+             AlertStyle="AlertStyle.Success"
              AllowClose="false"
              Title="@L["Reset password confirmation"]"
              Text="@L["Your password has been reset."]"  />

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Pages/ConfirmEmail.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Pages/ConfirmEmail.razor
@@ -1,57 +1,25 @@
-﻿@*
+@*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
 *@
-
-@* @page "/ConfirmEmail"
+@page "/ConfirmEmail"
 
 @inherits AdminComponentBase
 
-@using System.Text
-@using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.WebUtilities
+<PageTitle>@L["Confirm email"]</PageTitle>
 
+<RadzenText Text="@L["Confirm email"]" TextStyle="TextStyle.H4" />
 
+<hr />
 
-@inject UserManager<ApplicationUser> UserManager
-@inject IdentityRedirectManager RedirectManager
-
-<PageTitle>Confirm email</PageTitle>
-
-<h1>Confirm email</h1>
-<StatusMessage Message="@statusMessage" />
-
-@code {
-    private string? statusMessage;
-
-    [CascadingParameter]
-    private HttpContext HttpContext { get; set; } = default!;
-
-    [SupplyParameterFromQuery]
-    private string? UserId { get; set; }
-
-    [SupplyParameterFromQuery]
-    private string? Code { get; set; }
-
-    protected override async Task OnInitializedAsync()
-    {
-        if (UserId is null || Code is null)
-        {
-            RedirectManager.RedirectTo(string.Empty);
-        }
-
-        var user = await UserManager.FindByIdAsync(UserId);
-        if (user is null)
-        {
-            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-            statusMessage = $"Error loading user with ID {UserId}";
-        }
-        else
-        {
-            var code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Code));
-            var result = await UserManager.ConfirmEmailAsync(user, code);
-            statusMessage = result.Succeeded ? "Thank you for confirming your email." : "Error confirming your email.";
-        }
-    }
+@if (_message != null)
+{
+    <RadzenAlert Shade="Shade.Lighter"
+                 Variant="Variant.Flat"
+                 Size="AlertSize.Small"
+                 AlertStyle="@_alertStyle"
+                 AllowClose="false"
+                 Text="@_message" />
 }
- *@
+
+<RadzenLink Path="/Login" Text="@L["Back to login"]" />

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Pages/ConfirmEmail.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Pages/ConfirmEmail.razor.cs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using System.Text;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Corsinvest.ProxmoxVE.Admin.Module.System.Security.Components.Account.Pages;
+
+public partial class ConfirmEmail(UserManager<ApplicationUser> userManager,
+                                  NavigationManager navigationManager)
+{
+    [SupplyParameterFromQuery] private string? UserId { get; set; }
+    [SupplyParameterFromQuery] private string? Code { get; set; }
+
+    private string? _message;
+    private AlertStyle _alertStyle;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (UserId is null || Code is null)
+        {
+            navigationManager.NavigateTo("/");
+            return;
+        }
+
+        var user = await userManager.FindByIdAsync(UserId);
+        if (user is null)
+        {
+            _message = L["Invalid confirmation link."];
+            _alertStyle = AlertStyle.Danger;
+            return;
+        }
+
+        var code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Code));
+        var result = await userManager.ConfirmEmailAsync(user, code);
+
+        if (result.Succeeded)
+        {
+            _message = L["Email confirmed. You can now reset your password to login."];
+            _alertStyle = AlertStyle.Success;
+        }
+        else
+        {
+            _message = L["Error confirming your email."];
+            _alertStyle = AlertStyle.Danger;
+        }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ public static class ServiceCollectionExtensions
         {
             options.User.RequireUniqueEmail = true;
             options.SignIn.RequireConfirmedEmail = true;
+            options.SignIn.RequireConfirmedAccount = true;
 
             //read from settings
             var sectionPasswordOptions = configuration.GetSection("Security:PasswordOptions");
@@ -82,7 +83,6 @@ public static class ServiceCollectionExtensions
 
             // 2FA settings
             options.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
-            options.SignIn.RequireConfirmedAccount = false;
         })
         .AddRoles<ApplicationRole>()
         .AddEntityFrameworkStores<ModuleDbContext>()
@@ -121,7 +121,7 @@ public static class ServiceCollectionExtensions
             };
 
             //default password
-            await userManager.CreateAsync(adminUser, ApplicationHelper.DefaultAdminPassword);
+            await userManager.CreateAsync(adminUser, ApplicationHelper.DefaultUserPassword);
         }
 
         var roleManager = services.GetRequiredService<RoleManager<ApplicationRole>>();


### PR DESCRIPTION
## Summary
- Add `GenerateRandomPassword()`, `SendConfirmationAsync()`, `SendPasswordResetAsync()`, `GeneratePasswordResetLinkAsync()` to `IdentityExtensions`
- New `ConfirmEmail.razor` page (`/ConfirmEmail`) — was previously commented out
- Simplify `ForgotPassword` to use `SendPasswordResetAsync()`
- Fix `ResetPasswordConfirmation` alert style (`Warning` → `Success`)
- Enable `RequireConfirmedEmail` and `RequireConfirmedAccount`

## Test plan
- [ ] New user creation sends confirmation email
- [ ] Confirmation link redirects to `/ConfirmEmail` and confirms account
- [ ] Forgot password sends reset link correctly
- [ ] Login blocked until email confirmed