### PR TITLE
chore: bump dependencies (CE)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,15 +1,15 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Corsinvest.ProxmoxVE.NodeProtect.Api" Version="2.1.1" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="1.8.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
-    <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="6.2.0" />
+    <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="6.2.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="ToonEncoder" Version="2.0.0" />
   </ItemGroup>
@@ -20,15 +20,15 @@
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <!-- UI and Frontend -->
   <ItemGroup>
-    <PackageVersion Include="Radzen.Blazor" Version="10.3.0" />
+    <PackageVersion Include="Radzen.Blazor" Version="10.4.3" />
     <PackageVersion Include="OpenLayers.Blazor" Version="2.5.0" />
   </ItemGroup>
   <!-- Utilities and Tools -->
@@ -41,13 +41,15 @@
     <PackageVersion Include="BlazorDownloadFile" Version="2.4.0.2" />
     <PackageVersion Include="FluentResults" Version="4.0.0" />
     <PackageVersion Include="CronExpressionDescriptor" Version="2.45.0" />
-    <PackageVersion Include="cronos" Version="0.12.0" />
+    <PackageVersion Include="cronos" Version="0.13.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
+    <!-- 3.1.12: latest 3.x (Apache-2.0) with all known CVEs fixed.
+         DO NOT upgrade to v4.x: switched to Six Labors Split License (commercial). -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
   <!-- Scheduling and Background Jobs -->
   <ItemGroup>
@@ -59,11 +61,11 @@
   </ItemGroup>
   <!-- Proxmox VE -->
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.15" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.18" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.TelegramBot.Api" Version="1.9.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Metrics.Exporter.Api" Version="2.0.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.AutoSnap.Api" Version="2.1.1" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Diagnostic.Api" Version="2.2.2" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Diagnostic.Api" Version="2.2.4" />
   </ItemGroup>
   <!-- Development and Code Quality -->
   <ItemGroup>
@@ -71,8 +73,8 @@
   </ItemGroup>
   <!-- MCP Server -->
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Wangkanai.Detection" Version="8.20.0" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,99 +1,45 @@
-# Third-Party Notices and Legal Disclaimers
+# Third-Party Notices
 
-This project incorporates components from the following third-party projects. The original copyright statements and license terms are linked below.
-
----
-
-## 1. Core Frameworks & Runtimes
-
-| Component | License | Project / Source |
-| --- | --- | --- |
-| **.NET Runtime & SDK** | MIT | [dotnet/runtime](https://github.com/dotnet/runtime) |
-| **ASP.NET Core Framework** | MIT | [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore) |
-| **.NET Aspire SDK** | MIT | [dotnet/aspire](https://github.com/dotnet/aspire) |
-
----
-
-## 2. .NET NuGet Packages
+This project incorporates components from the following third-party projects.
 
 | Package | License | Project Link |
 | --- | --- | --- |
 | **BlazorDownloadFile** | MIT | [BlazorDownloadFile](https://github.com/arivera12/BlazorDownloadFile) |
-| **ClosedXML & Reports** | MIT | [ClosedXML](https://github.com/ClosedXML/ClosedXML) |
+| **ClosedXML & ClosedXML.Report** | MIT | [ClosedXML](https://github.com/ClosedXML/ClosedXML) |
 | **cronos** | MIT | [cronos](https://github.com/HangfireIO/Cronos) |
 | **CronExpressionDescriptor** | MIT | [CronExpressionDescriptor](https://github.com/bradymholt/cron-expression-descriptor) |
 | **CsvHelper** | MS-PL / Apache-2.0 | [CsvHelper](https://github.com/JoshClose/CsvHelper) |
-| **Elsa Workflows** | MIT | [Elsa](https://github.com/elsa-workflows/elsa-core) |
+| **cv4pve-api-dotnet** | MIT | [cv4pve-api-dotnet](https://github.com/Corsinvest/cv4pve-api-dotnet) |
+| **cv4pve-autosnap** | GPL-3.0-only | [cv4pve-autosnap](https://github.com/Corsinvest/cv4pve-autosnap) |
+| **cv4pve-botgram** | GPL-3.0-only | [cv4pve-botgram](https://github.com/Corsinvest/cv4pve-botgram) |
+| **cv4pve-diag** | GPL-3.0-only | [cv4pve-diag](https://github.com/Corsinvest/cv4pve-diag) |
+| **cv4pve-metrics-exporter** | GPL-3.0-only | [cv4pve-metrics-exporter](https://github.com/Corsinvest/cv4pve-metrics-exporter) |
+| **cv4pve-nodeprotect** | GPL-3.0-only | [cv4pve-nodeprotect](https://github.com/Corsinvest/cv4pve-nodeprotect) |
+| **cv4pve-report** | GPL-3.0-only | [cv4pve-report](https://github.com/Corsinvest/cv4pve-report) |
 | **Entity Framework Core** | MIT | [EF Core](https://github.com/dotnet/efcore) |
 | **FluentResults** | MIT | [FluentResults](https://github.com/altmann/FluentResults) |
-| **Hangfire (Core & Storage)** | LGPL-3.0 | [Hangfire](https://github.com/HangfireIO/Hangfire) |
-| **HtmlAgilityPack** | MIT | [HtmlAgilityPack](https://github.com/zzzprojects/html-agility-pack) |
+| **Hangfire (Core, AspNetCore, PostgreSQL)** | LGPL-3.0 | [Hangfire](https://github.com/HangfireIO/Hangfire) |
+| **Hangfire.Console & Extensions** | MIT | [Hangfire.Console](https://github.com/pieceofsummer/Hangfire.Console) |
 | **Humanizer** | MIT | [Humanizer](https://github.com/Humanizr/Humanizer) |
-| **Lextm.SharpSnmpLib** | MIT | [SharpSnmpLib](https://github.com/lextm/sharpsnmplib) |
-| **LibGit2Sharp** | MIT | [LibGit2Sharp](https://github.com/libgit2/libgit2sharp) |
 | **MailKit** | MIT | [MailKit](https://github.com/jstedfast/MailKit) |
 | **Mapster** | MIT | [Mapster](https://github.com/MapsterMapper/Mapster) |
-| **Microsoft.AspNetCore.SignalR.Client** | MIT | [SignalR](https://github.com/dotnet/aspnetcore) |
 | **Microsoft.Extensions.ServiceDiscovery** | MIT | [Aspire ServiceDiscovery](https://github.com/dotnet/aspire) |
 | **Model Context Protocol (MCP)** | Apache-2.0 | [MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk) |
 | **Npgsql (EF Core PostgreSQL)** | PostgreSQL | [Npgsql](https://github.com/npgsql/efcore.pg) |
 | **OpenLayers.Blazor** | MIT | [OpenLayers.Blazor](https://github.com/loiste-interactive/OpenLayers-Blazor) |
 | **OpenTelemetry .NET** | Apache-2.0 | [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet) |
-| **Otp.NET** | MIT | [Otp.NET](https://github.com/kspearrin/Otp.NET) |
 | **PDFsharp & MigraDoc** | MIT | [PDFsharp](https://github.com/empira/PDFsharp) |
 | **Radzen.Blazor** | MIT | [Radzen.Blazor](https://github.com/radzenhq/radzen-blazor) |
+| **Roslynator.Analyzers** | MIT | [Roslynator](https://github.com/dotnet/roslynator) |
 | **Semver** | MIT | [Semver](https://github.com/maxhauser/semver) |
 | **Serilog Ecosystem** | Apache-2.0 | [Serilog](https://github.com/serilog/serilog) |
-| **Serilog.UI** | MIT | [Serilog.UI](https://github.com/followynne/serilog-ui) |
-| **Serilog.Sinks.Postgresql.Alternative** | MIT | [Serilog.Sinks.Postgresql](https://github.com/b00ted/serilog-sinks-postgresql) |
-| **SixLabors.ImageSharp** | Apache-2.0 | [ImageSharp](https://github.com/SixLabors/ImageSharp) |
+| **SixLabors.ImageSharp** (v3.x) | Apache-2.0 | [ImageSharp](https://github.com/SixLabors/ImageSharp) |
 | **SSH.NET** | MIT | [SSH.NET](https://github.com/sshnet/SSH.NET) |
 | **System.CommandLine** | MIT | [System.CommandLine](https://github.com/dotnet/command-line-api) |
-| **System.Linq.Dynamic.Core** | MIT | [Dynamic LINQ](https://github.com/zzzprojects/System.Linq.Dynamic.Core) |
-| **Toolbelt.Blazor.HotKeys2** | MIT | [HotKeys2](https://github.com/jsakamoto/Toolbelt.Blazor.HotKeys2) |
+| **System.Linq.Dynamic.Core** | Apache-2.0 | [Dynamic LINQ](https://github.com/zzzprojects/System.Linq.Dynamic.Core) |
+| **Toolbelt.Blazor.HotKeys2** | MPL-2.0 | [HotKeys2](https://github.com/jsakamoto/Toolbelt.Blazor.HotKeys2) |
 | **ToonEncoder** | MIT | [ToonEncoder](https://github.com/gfoidl/ToonEncoder) |
 | **Wangkanai.Detection** | Apache-2.0 | [Detection](https://github.com/wangkanai/wangkanai) |
 | **ZiggyCreatures.FusionCache** | MIT | [FusionCache](https://github.com/ZiggyCreatures/FusionCache) |
 
-### Proxmox VE Integration (Corsinvest)
-
-*Licensed under **MIT**:*
-[cv4pve-api-dotnet](https://github.com/Corsinvest/cv4pve-api-dotnet)
-
-*Licensed under **GPL-3.0-only**:*
-[cv4pve-autosnap](https://github.com/Corsinvest/cv4pve-autosnap) | [cv4pve-diag](https://github.com/Corsinvest/cv4pve-diag) | [cv4pve-metrics-exporter](https://github.com/Corsinvest/cv4pve-metrics-exporter) | [cv4pve-botgram](https://github.com/Corsinvest/cv4pve-botgram)
-
----
-
-## 3. Docker Container Images
-
-| Component | License | Source / Repository |
-| --- | --- | --- |
-| **PostgreSQL Database** | PostgreSQL | [PostgreSQL (Official Image)](https://hub.docker.com/_/postgres) |
-| **PgWeb (DB Admin)** | MIT | [sosedoff/pgweb](https://github.com/sosedoff/pgweb) |
-| **Watchtower (Auto Updates)** | Apache-2.0 | [containrrr/watchtower](https://github.com/containrrr/watchtower) |
-| **Apprise (Notifications)** | MIT | [caronc/apprise-api](https://github.com/caronc/apprise-api) |
-
----
-
-## 4. License Compatibility
-
-CV4PVE Admin Community Edition is licensed under **AGPL-3.0-only**.
-
-* ✅ **Permissive (MIT, Apache-2.0, PostgreSQL, MS-PL):** Fully compatible.
-* ✅ **Weak Copyleft (LGPL-3.0):** Compatible via dynamic linking as used.
-* ⚠️ **Strong Copyleft (GPL-3.0-only):** Compatible when used in accordance with Corsinvest's specific architectural requirements.
-
----
-
-## 5. Additional Information
-
-* **Transitive Dependencies:** All sub-dependencies are governed by OSI-approved licenses (primarily MIT or Apache-2.0).
-* **Note on Docker Images:** These images are pulled at runtime during deployment and are not bundled with the source code.
-* **Enterprise Edition:** Proprietary modules are subject to a separate commercial license agreement.
-
-**Contact:** Corsinvest Srl | support@corsinvest.it | [www.corsinvest.it](https://www.corsinvest.it)
-
----
-
-*Document updated: March 2026*
+*Document updated: May 2026*

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.2" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.1.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Bump CE direct packages to latest stable
- Update `THIRD-PARTY-NOTICES.md` to reflect the current dependency list

## Notable bumps
- **Corsinvest.ProxmoxVE.Report 1.8.0 → 2.3.0** — `NetworkDiagramBuilder.BuildSvg` adds a required `SdnVnetRow` parameter
- **EF Core / ASP.NET Core Identity / Diagnostics 10.0.6 → 10.0.8**
- **Microsoft.Extensions.ServiceDiscovery 10.5.0 → 10.6.0**
- **Radzen.Blazor 10.3.0 → 10.4.3**
- **OpenTelemetry 1.15.x → 1.15.3**
- **ModelContextProtocol(.AspNetCore) 1.2.0 → 1.3.0**
- **Corsinvest.ProxmoxVE.Api.Extension 9.1.15 → 9.1.18**
- **cronos 0.12.0 → 0.13.0**, **System.CommandLine 2.0.6 → 2.0.8**, **HotKeys2 6.2.0 → 6.2.1**
- **Corsinvest.ProxmoxVE.Diagnostic.Api 2.2.2 → 2.2.4**
- AppHost: **Aspire 13.2.2 → 13.3.4**, **CommunityToolkit.MailPit 13.1.1 → 13.3.0**

## Notes
- **SixLabors.ImageSharp**: kept at 3.1.12 + added an inline comment to prevent accidental upgrade to v4 (v4 switched to Six Labors Split License — commercial).
- **THIRD-PARTY-NOTICES.md**: realigned with the actual direct dependencies (added `Roslynator.Analyzers`, dropped non-existent `Hangfire.NetCore`).

⚠️ **This commit alone does not build.** `BuildSvg` call-site in `Networks.razor.cs` needs to be updated to pass the new `SdnVnetRow` parameter. The follow-up PR will contain the call-site fix along with other unrelated refactors.

## Test plan
- [ ] CI verifies that the only build error is the expected `NetworkDiagramBuilder.BuildSvg` signature mismatch (Report 2.3.0 breaking change)
- [ ] No `NU1902` vulnerability warnings
- [ ] Follow-up PR brings the build back to green