### PR TITLE
refactor: use IBrowserService.DownloadFileAsync across modules

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AIServer/Components/Bridge.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AIServer/Components/Bridge.razor.cs
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
-using BlazorDownloadFile;
 using Microsoft.AspNetCore.Components;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.AIServer.Components;
 
 public partial class Bridge(NavigationManager navigationManager,
-                            IBrowserService browserService,
-                            IBlazorDownloadFileService blazorDownloadFileService)
+                            IBrowserService browserService)
 {
     private static readonly JsonSerializerOptions jsonSerializerOptions = new() { WriteIndented = true };
     private record PlatformInfo(string Icon, string Platform, string File);
@@ -69,9 +66,9 @@ public partial class Bridge(NavigationManager navigationManager,
     }
 
     private async Task DownloadClaudeConfigAsync()
-        => await blazorDownloadFileService.DownloadFile("claude_desktop_config.json",
-                                                        Encoding.UTF8.GetBytes(BuildClaudeConfigJson()),
-                                                        MediaTypeNames.Application.Json);
+        => await browserService.DownloadFileAsync("claude_desktop_config.json",
+                                                  BuildClaudeConfigJson(),
+                                                  MediaTypeNames.Application.Json);
 
     private Task CopyClaudeConfigAsync()
         => browserService.CopyToClipboardAsync(BuildClaudeConfigJson());

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor.cs
@@ -4,7 +4,6 @@
  */
 using System.Net.Mime;
 using System.Text.Json;
-using BlazorDownloadFile;
 using Corsinvest.ProxmoxVE.Admin.Core.Components.WidgetGrid;
 using Corsinvest.ProxmoxVE.Admin.Core.Configuration;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Identity;
@@ -16,7 +15,7 @@ namespace Corsinvest.ProxmoxVE.Admin.Module.Dashboard.Components;
 public partial class Dashboard(IDbContextFactory<ModuleDbContext> dbContextFactory,
                                IModuleService moduleService,
                                ICurrentUserService currentUserService,
-                               IBlazorDownloadFileService blazorDownloadFileService,
+                               IBrowserService browserService,
                                IJSRuntime jSRuntime,
                                ContextMenuService contextMenuService,
                                DialogService dialogService,
@@ -472,7 +471,7 @@ public partial class Dashboard(IDbContextFactory<ModuleDbContext> dbContextFacto
         await using var ms = new MemoryStream();
         await JsonSerializer.SerializeAsync(ms, CurrentDashboard, _jsonSerializerOptions);
         ms.Position = 0;
-        await blazorDownloadFileService.DownloadFile($"dashboard-{CurrentDashboard.Name}.json", ms, MediaTypeNames.Application.Json);
+        await browserService.DownloadFileAsync($"dashboard-{CurrentDashboard.Name}.json", ms, MediaTypeNames.Application.Json);
     }
     #endregion
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using BlazorDownloadFile;
+using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Services;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Components;
 
-public partial class Scans(IBlazorDownloadFileService blazorDownloadFileService,
+public partial class Scans(IBrowserService browserService,
                              IDbContextFactory<ModuleDbContext> dbContextFactory,
                              IBackgroundJobService backgroundJobService,
                              ISettingsService settingsService,
@@ -115,7 +115,7 @@ public partial class Scans(IBlazorDownloadFileService blazorDownloadFileService,
         await using var db = await dbContextFactory.CreateDbContextAsync();
         var result = (await db.JobResults.Include(a => a.Details).FromIdAsync(SelectedItems[0].Id))!;
         await using var ms = diagnosticService.GeneratePdf(result);
-        await blazorDownloadFileService.DownloadFile($"Diagnostic-{result.ClusterName}-{result.Start}.pdf", ms, MediaTypeNames.Application.Pdf);
+        await browserService.DownloadFileAsync($"Diagnostic-{result.ClusterName}-{result.Start}.pdf", ms, MediaTypeNames.Application.Pdf);
 
         InDownload = false;
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using BlazorDownloadFile;
+using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Models;
 using Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Persistence;
 
@@ -12,7 +12,7 @@ namespace Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Folder.Components;
 public partial class Render(IDbContextFactory<ModuleDbContext> dbContextFactory,
                             IBackgroundJobService backgroundJobService,
                             ISettingsService settingsService,
-                            IBlazorDownloadFileService blazorDownloadFileService,
+                            IBrowserService browserService,
                             DialogService dialogService,
                             NotificationService notificationService,
                             EventNotificationService eventNotificationService) : IRefreshableData,
@@ -96,7 +96,7 @@ public partial class Render(IDbContextFactory<ModuleDbContext> dbContextFactory,
         if (File.Exists(item.GetPath(ClusterName)))
         {
             await using var fs = File.OpenRead(item.GetPath(ClusterName));
-            await blazorDownloadFileService.DownloadFile(item.FileName, fs, MediaTypeNames.Application.GZip);
+            await browserService.DownloadFileAsync(item.FileName, fs, MediaTypeNames.Application.GZip);
         }
         InDownload = false;
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using BlazorDownloadFile;
+using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Helpers;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Models;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Services;
@@ -13,7 +13,7 @@ namespace Corsinvest.ProxmoxVE.Admin.Module.Updater.Components;
 public partial class Scans(IAdminService adminService,
                          IBackgroundJobService backgroundJobService,
                          ISettingsService settingsService,
-                         IBlazorDownloadFileService blazorDownloadFileService,
+                         IBrowserService browserService,
                          NotificationService notificationService,
                          IUpdaterService updaterService,
                          EventNotificationService eventNotificationService) : IRefreshableData,
@@ -71,7 +71,7 @@ public partial class Scans(IAdminService adminService,
 
         var start = Items.Min(a => a.UpdateScanTimestamp)!;
         await using var ms = updaterService.GeneratePdf(ClusterName, Items);
-        await blazorDownloadFileService.DownloadFile($"Update-{ClusterName}-{start}.pdf", ms, MediaTypeNames.Application.Pdf);
+        await browserService.DownloadFileAsync($"Update-{ClusterName}-{start}.pdf", ms, MediaTypeNames.Application.Pdf);
 
         InDownload = false;
     }


### PR DESCRIPTION
## Summary

Migrate five modules from a direct `IBlazorDownloadFileService` dependency to the unified `IBrowserService.DownloadFileAsync` API introduced in #296.

Centralises the download entry point on a single Core service, so the underlying download implementation can evolve without touching module DI graphs.

## Modules updated

- `Module.AIServer/Components/Bridge.razor.cs` — Claude config JSON download
- `Module.Dashboard/Components/Dashboard.razor.cs` — dashboard export JSON
- `Module.Diagnostic/Components/Scans.razor.cs` — diagnostic PDF download
- `Module.NodeProtect/Folder/Components/Render.razor.cs` — backup archive download
- `Module.Updater/Components/Scans.razor.cs` — updater PDF download

The five constructors drop `IBlazorDownloadFileService` and rely on the already-injected `IBrowserService`. `Bridge.razor.cs` also drops a now-unused `using System.Text` (was only there for `Encoding.UTF8` — the text overload of `DownloadFileAsync` handles encoding internally).

## Behaviour

Functionally equivalent — same file names, same MIME types, same payloads. The only observable change is one fewer service in each module's DI graph.

## Test plan

- [ ] CI builds the five modules green
- [ ] Smoke test each download flow (AIServer Claude config, Dashboard export, Diagnostic PDF, NodeProtect backup, Updater PDF) and confirm the file is delivered as before

## Depends on

- #296 (Core: BrowserService.DownloadFileAsync API)