### PR TITLE
fix(resources): align with Report 2.3.0 (restores CI build) + SDN tab + Disks Kind column

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Disks.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Disks.razor
@@ -44,6 +44,7 @@
         <RadzenDataGridColumn Property="@nameof(Data.Type)" Title="@L["Type"]" Visible="false" />
         <RadzenDataGridColumn Property="@nameof(Data.Status)" Title="@L["Status"]" Visible="false" />
         <RadzenDataGridColumn Property="@nameof(Data.Id)" Title="@L["Id"]" />
+        <RadzenDataGridColumn Property="@nameof(Data.Kind)" Title="@L["Kind"]" />
         <RadzenDataGridColumn Property="@nameof(Data.Storage)" Title="@L["Storage"]" />
         <RadzenDataGridColumn Property="@nameof(Data.PluginType)" Title="@L["PluginType"]" />
         <BoolIconColumn TItem="Data" Property="@nameof(Data.Shared)" Title="@L["Shared"]" IconFalse="" />

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Disks.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Disks.razor.cs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
+
 namespace Corsinvest.ProxmoxVE.Admin.Module.Resources.Components;
 
 public partial class Disks(IAdminService adminService) : IClusterName, IRefreshableData
@@ -20,6 +22,7 @@ public partial class Disks(IAdminService adminService) : IClusterName, IRefresha
                         string Type,
                         string Status,
                         bool IsLocked,
+                        VmDiskKind Kind,
                         string Id,
                         string Storage,
                         string? PluginType,
@@ -58,7 +61,7 @@ public partial class Disks(IAdminService adminService) : IClusterName, IRefresha
                         async item =>
                         {
                             var config = await clusterClient.CachedData.GetGuestConfigAsync(item.Node, item.VmType, item.VmId, false);
-                            return config.Disks.Select(disk =>
+                            return config.DisksAll.Select(disk =>
                             {
                                 storageLookup.TryGetValue((item.Node, disk.Storage), out var storageRes);
 
@@ -69,6 +72,7 @@ public partial class Disks(IAdminService adminService) : IClusterName, IRefresha
                                                 item.Type,
                                                 item.Status,
                                                 item.IsLocked,
+                                                disk.Kind,
                                                 disk.Id,
                                                 disk.Storage,
                                                 storageRes?.PluginType,

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Networks.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Networks.razor
@@ -105,6 +105,51 @@
                     </Columns>
                 </RadzenDataGrid>
             </RadzenTabsItem>
+
+            <RadzenTabsItem Text="SDN" Icon="hub">
+                <RadzenDataGrid Data="@SdnVnets"
+                                AllowFiltering="true"
+                                AllowColumnResize="true"
+                                AllowAlternatingRows="false"
+                                AllowSorting="true"
+                                FilterPopupRenderMode="PopupRenderMode.OnDemand"
+                                IsLoading="IsLoadingSdn"
+                                AllowColumnPicking="true"
+                                FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive">
+                    <HeaderTemplate>
+                        <CrudToolbar OnRefresh="RefreshDataAsync" />
+                    </HeaderTemplate>
+
+                    <Columns>
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.Vnet)" Title="@L["Vnet"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.Zone)" Title="@L["Zone"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.ZoneType)" Title="@L["Zone Type"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.ZoneBridge)" Title="@L["Bridge"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.Tag)" Title="@L["Tag"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.Alias)" Title="@L["Alias"]" />
+                        <RadzenDataGridColumn Property="@nameof(SdnVnet.Nodes)" Title="@L["Nodes"]" />
+                    </Columns>
+                </RadzenDataGrid>
+            </RadzenTabsItem>
+
+            <RadzenTabsItem Text="@L["Diagram"]" Icon="lan">
+                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="4px">
+                    <CrudToolbar OnRefresh="RefreshDataAsync" />
+                    <RadzenButton Icon="download" Text="@L["Download"]" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
+                                  Disabled="@string.IsNullOrEmpty(NetworkDiagramSvg)"
+                                  Click="DownloadDiagramAsync" />
+                </RadzenStack>
+                @if (IsLoadingDiagram)
+                {
+                    <RadzenProgressBar ProgressBarStyle="ProgressBarStyle.Primary" Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
+                }
+                else if (!string.IsNullOrEmpty(NetworkDiagramSvg))
+                {
+                    <div style="overflow:auto; width:100%;">
+                        @((MarkupString)NetworkDiagramSvg)
+                    </div>
+                }
+            </RadzenTabsItem>
         </Tabs>
     </RadzenTabs>
 </RadzenPanel>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Networks.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Networks.razor.cs
@@ -1,25 +1,34 @@
 /*
+using static Corsinvest.ProxmoxVE.Admin.Core.BuildInfo;
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+using Corsinvest.ProxmoxVE.Admin.Core;
+using Corsinvest.ProxmoxVE.Api;
 using Corsinvest.ProxmoxVE.Api.Extension;
+using Corsinvest.ProxmoxVE.Api.Extension.Utils;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.Resources.Components;
 
-public partial class Networks(IAdminService adminService) : IClusterName, IRefreshableData
+public partial class Networks(IAdminService adminService,
+                              ISettingsService settingsService,
+                              IBrowserService browserService) : IClusterName, IRefreshableData
 {
     [CascadingParameter(Name = nameof(ClusterName))] public string ClusterName { get; set; } = default!;
 
     private List<VmNetwork> VmNetworks { get; set; } = [];
     private List<NodeNetwork> NodeNetworks { get; set; } = [];
+    private List<SdnVnet> SdnVnets { get; set; } = [];
     private bool IsLoadingNodes { get; set; }
     private bool IsLoadingGuests { get; set; }
+    private bool IsLoadingSdn { get; set; }
     private RadzenDataGrid<VmNetwork> DataGridRef { get; set; } = default!;
     private int SelectedTab { get; set; }
     private bool _nodesLoaded;
     private bool _guestsLoaded;
+    private bool _sdnLoaded;
 
     private record NodeNetwork(string Node,
                                bool Active,
@@ -64,6 +73,14 @@ public partial class Networks(IAdminService adminService) : IClusterName, IRefre
                                string Comments,
                                string Comments6);
 
+    private record SdnVnet(string Vnet,
+                           string Zone,
+                           string ZoneType,
+                           string? ZoneBridge,
+                           int? Tag,
+                           string? Alias,
+                           string Nodes);
+
     private record VmNetwork(string Node,
                              long VmId,
                              string Name,
@@ -86,6 +103,10 @@ public partial class Networks(IAdminService adminService) : IClusterName, IRefre
                              int? Mtu,
                              double? Rate);
 
+    private bool _diagramLoaded;
+    private bool IsLoadingDiagram { get; set; }
+    private string NetworkDiagramSvg { get; set; } = string.Empty;
+
     private bool _groupAdded;
 
     protected override Task OnInitializedAsync() => RefreshDataAsync();
@@ -106,29 +127,178 @@ public partial class Networks(IAdminService adminService) : IClusterName, IRefre
 
     public async Task RefreshDataAsync()
     {
-        if (SelectedTab == 0)
+        switch (SelectedTab)
         {
-            _nodesLoaded = false;
-            await LoadNoteNetworksAsync();
-        }
-        else
-        {
-            _guestsLoaded = false;
-            await LoadVmNetworksAsync();
+            case 0:
+                _nodesLoaded = false;
+                await LoadNoteNetworksAsync();
+                break;
+            case 1:
+                _guestsLoaded = false;
+                await LoadVmNetworksAsync();
+                break;
+            case 2:
+                _sdnLoaded = false;
+                await LoadSdnAsync();
+                break;
+            default:
+                _diagramLoaded = false;
+                await LoadDiagramAsync();
+                break;
         }
     }
 
     public async Task OnTabChangeAsync(int index)
     {
         SelectedTab = index;
-        if (index == 0 && !_nodesLoaded)
+        switch (index)
         {
-            await LoadNoteNetworksAsync();
+            case 0 when !_nodesLoaded: await LoadNoteNetworksAsync(); break;
+            case 1 when !_guestsLoaded: await LoadVmNetworksAsync(); break;
+            case 2 when !_sdnLoaded: await LoadSdnAsync(); break;
+            case 3 when !_diagramLoaded: await LoadDiagramAsync(); break;
         }
-        else if (index == 1 && !_guestsLoaded)
+    }
+
+    public async Task LoadDiagramAsync()
+    {
+        IsLoadingDiagram = true;
+        NetworkDiagramSvg = string.Empty;
+        await InvokeAsync(StateHasChanged);
+
+        var clusterClient = adminService[ClusterName];
+        var client = await clusterClient.GetPveClientAsync();
+
+        var resources = await clusterClient.CachedData.GetResourcesAsync(false);
+        var nodes = resources.Where(a => a.ResourceType == ClusterResourceType.Node).ToList();
+        var vms = resources.Where(a => a.ResourceType == ClusterResourceType.Vm).ToList();
+
+        // Node networks
+        var hostNets = (await ParallelHelper.RunManyAsync(nodes, async item =>
         {
-            await LoadVmNetworksAsync();
-        }
+            var nets = await client.Nodes[item.Node].Network.GetAsync();
+            return nets.Select(n => new NetworkDiagramBuilder.NodeNetworkRow(item.Node, n));
+        })).ToList();
+
+        // VM networks
+        var vmNets = (await ParallelHelper.RunManyAsync(vms, async item =>
+        {
+            var config = await clusterClient.CachedData.GetGuestConfigAsync(item.Node, item.VmType, item.VmId, false);
+            var networks = config?.Networks ?? [];
+            switch (item.VmType)
+            {
+                case VmType.Qemu:
+                    var qemuNetsTask = clusterClient.CachedData.GetQemuNetworkAsync(item.Node, item.VmId, false).AsTask();
+                    var hostnameTask = clusterClient.CachedData.GetQemuHostnameAsync(item.Node, item.VmId, false).AsTask();
+                    await Task.WhenAll(qemuNetsTask, hostnameTask);
+
+                    var netDict = networks.Where(n => !string.IsNullOrEmpty(n.MacAddress))
+                                          .ToDictionary(n => n.MacAddress!, StringComparer.OrdinalIgnoreCase);
+
+                    return [.. qemuNetsTask.Result.Result
+                                           .Where(a => !string.IsNullOrEmpty(a.HardwareAddress) && a.HardwareAddress != "00:00:00:00:00:00")
+                                           .Select(net =>
+                                           {
+                                                var hasConfig = netDict.TryGetValue(net.HardwareAddress!, out var configNet);
+                                                return new NetworkDiagramBuilder.VmNetworkRow(item.VmId,
+                                                                                              item.Name,
+                                                                                              item.Node,
+                                                                                              item.Type,
+                                                                                              item.Status,
+                                                                                              hostnameTask.Result,
+                                                                                              configNet ?? new(),
+                                                                                              !hasConfig);
+                                           })];
+
+                case VmType.Lxc:
+                    return networks.Select(n => new NetworkDiagramBuilder.VmNetworkRow(item.VmId,
+                                                                                       item.Name,
+                                                                                       item.Node,
+                                                                                       item.Type,
+                                                                                       item.Status,
+                                                                                       (config as VmConfigLxc)?.Hostname,
+                                                                                       n,
+                                                                                       false));
+
+                default: return [];
+            }
+        })).ToList();
+
+        var storageTask = client.Storage.GetAsync();
+        var sdnRowsTask = FetchSdnRowsAsync(client, nodes);
+        await Task.WhenAll(storageTask, sdnRowsTask);
+
+        var storages = storageTask.Result.ToList();
+
+        NetworkDiagramSvg = NetworkDiagramBuilder.BuildSvg(
+            hostNets,
+            sdnRowsTask.Result,
+            vmNets,
+            storages,
+            new NetworkDiagramBuilder.DiagramInfo(settingsService.GetAppSettings().AppName, ApplicationHelper.GitHubRepoUrl, BuildInfo.Version));
+
+        IsLoadingDiagram = false;
+        _diagramLoaded = true;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private static async Task<List<NetworkDiagramBuilder.SdnVnetRow>> FetchSdnRowsAsync(PveClient client,
+                                                                                       List<ClusterResource> nodes)
+    {
+        var vnetsTask = client.Cluster.Sdn.Vnets.GetAsync();
+        var zonesTask = client.Cluster.Sdn.Zones.GetAsync();
+        await Task.WhenAll(vnetsTask, zonesTask);
+
+        var zones = zonesTask.Result;
+        return [.. vnetsTask.Result.Select(v =>
+        {
+            var zone = zones.FirstOrDefault(z => z.Zone == v.Zone);
+            var zoneNodes = string.IsNullOrEmpty(zone?.Nodes)
+                ? (IReadOnlyList<string>)[.. nodes.Select(n => n.Node)]
+                : [.. zone.Nodes.Split(',').Select(s => s.Trim())];
+            return new NetworkDiagramBuilder.SdnVnetRow(
+                Vnet: v.Vnet ?? "",
+                Zone: v.Zone ?? "",
+                ZoneType: zone?.Type ?? "simple",
+                ZoneBridge: zone?.Bridge,
+                Tag: v.Tag,
+                Alias: v.Alias,
+                Nodes: zoneNodes);
+        })];
+    }
+
+    public async Task LoadSdnAsync()
+    {
+        IsLoadingSdn = true;
+        SdnVnets = [];
+        await InvokeAsync(StateHasChanged);
+
+        var clusterClient = adminService[ClusterName];
+        var client = await clusterClient.GetPveClientAsync();
+        var nodes = (await clusterClient.CachedData.GetResourcesAsync(false))
+                        .Where(a => a.ResourceType == ClusterResourceType.Node)
+                        .ToList();
+
+        var rows = await FetchSdnRowsAsync(client, nodes);
+        SdnVnets = [.. rows.Select(r => new SdnVnet(r.Vnet,
+                                                    r.Zone,
+                                                    r.ZoneType,
+                                                    r.ZoneBridge,
+                                                    r.Tag,
+                                                    r.Alias,
+                                                    string.Join(", ", r.Nodes)))];
+
+        IsLoadingSdn = false;
+        _sdnLoaded = true;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task DownloadDiagramAsync()
+    {
+        if (string.IsNullOrEmpty(NetworkDiagramSvg)) { return; }
+        await browserService.DownloadFileAsync($"network-diagram-{ClusterName}.svg",
+                                               NetworkDiagramSvg,
+                                               "image/svg+xml");
     }
 
     public async Task LoadNoteNetworksAsync()


### PR DESCRIPTION
## Summary

Restores the build after #295 bumped `Corsinvest.ProxmoxVE.Report` from 1.8.0 to 2.3.0, which changed the signature of `NetworkDiagramBuilder.BuildSvg`. While we were in `Networks.razor.cs` we also expose the newly-required SDN data as a dedicated tab, mirroring how `Corsinvest.ProxmoxVE.Report` itself surfaces it. Plus a small `Disks` enhancement that fell out of bumping `Corsinvest.ProxmoxVE.Api.Extension`.

## Networks — Report 2.3.0 BuildSvg breaking change

`BuildSvg` now requires an `SdnVnetRow` collection as its second argument. The diagram loader (`LoadDiagramAsync`) now fetches SDN vnets/zones alongside storages and feeds them in:

```csharp
var storageTask  = client.Storage.GetAsync();
var sdnRowsTask  = FetchSdnRowsAsync(client, nodes);
await Task.WhenAll(storageTask, sdnRowsTask);
NetworkDiagramSvg = NetworkDiagramBuilder.BuildSvg(hostNets, sdnRowsTask.Result, vmNets, storages, info);
```

`FetchSdnRowsAsync` mirrors the equivalent block in `Corsinvest.ProxmoxVE.Report` — vnet x zone lookup, fallback to all cluster nodes when the zone has no explicit node list.

## Networks — new SDN tab

Reusing the same `FetchSdnRowsAsync`, we expose SDN vnets as a dedicated tab between **Guests** and **Diagram** (same order as the Report sections). Columns: Vnet, Zone, Zone Type, Bridge, Tag, Alias, Nodes.

Tab indices are now `0 Nodes / 1 Guests / 2 SDN / 3 Diagram` (was `0 / 1 / 2`). Both `RefreshDataAsync` and `OnTabChangeAsync` updated accordingly with lazy-load (`_sdnLoaded`).

## Disks — Kind column

`Corsinvest.ProxmoxVE.Api.Extension 9.1.18` (also in #295) surfaces a `VmDiskKind` field on disk entries. Added it to the `Disks` data grid.

## Test plan

- [ ] CI builds CE green (this PR is the one that brings the build back)
- [ ] Open Resources → Networks → switch through all four tabs
- [ ] Diagram still renders (now showing SDN if configured)
- [ ] SDN tab populates if the cluster has vnets, empty otherwise (no crash)
- [ ] Disks tab shows the new Kind column

## Depends on

- #295 (which introduces the Report 2.3.0 breaking change this PR fixes)