### PR TITLE
feat(system-report): report format selector + single-file output

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/ReportDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/ReportDialog.razor
@@ -17,6 +17,13 @@
 
     <RadzenRow Gap="8px" class="rz-mb-2">
         <RadzenColumn Size="4">
+            <RadzenFormField Text="@L["Format"]" AllowFloatingLabel="false" class="rz-w-100">
+                <RadzenDropDown @bind-Value="@Model.Format"
+                                Data="@(Enum.GetValues<ReportFormat>())"
+                                ReadOnly="@ReadOnly" />
+            </RadzenFormField>
+        </RadzenColumn>
+        <RadzenColumn Size="4">
             <RadzenFormField Text="@L["Max Parallel Requests"]" AllowFloatingLabel="false" class="rz-w-100">
                 <ChildContent>
                     <RadzenNumeric @bind-Value="@S.MaxParallelRequests" Min="1" ReadOnly="@ReadOnly" />
@@ -41,8 +48,8 @@
     <RadzenAccordion>
         <Items>
             <RadzenAccordionItem Text="@L["Cluster"]" Icon="@PveAdminUIHelper.Icons.Cluster">
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Cluster.IncludeSheet" Label="@L["Include Sheet"]" ReadOnly="@ReadOnly" />
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Cluster.IncludeTasksSheet" Label="@L["Tasks Sheet"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Cluster.Include" Label="@L["Include"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Cluster.IncludeTasks" Label="@L["Tasks"]" ReadOnly="@ReadOnly" />
                 @RenderLog(S.Cluster.Log, L["Audit Log"])
             </RadzenAccordionItem>
 
@@ -55,7 +62,7 @@
                                ReadOnly="@ReadOnly"
                                class="rz-w-100 rz-mb-4" />
 
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Node.IncludeReplicationSheet" Label="@L["Replication Sheet"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Node.IncludeReplication" Label="@L["Replication"]" ReadOnly="@ReadOnly" />
 
                 @RenderRrdData(S.Node.RrdData)
                 @RenderSyslog(S.Node.Syslog)
@@ -83,9 +90,9 @@
                                ReadOnly="@ReadOnly"
                                class="rz-mb-4 rz-w-100" />
 
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludeSnapshotsSheet" Label="@L["Snapshots Sheet"]" ReadOnly="@ReadOnly" />
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludeDisksSheet" Label="@L["Disks Sheet"]" ReadOnly="@ReadOnly" />
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludePartitionsSheet" Label="@L["Partitions Sheet"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludeSnapshots" Label="@L["Snapshots"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludeDisks" Label="@L["Disks"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludePartitions" Label="@L["Partitions"]" ReadOnly="@ReadOnly" />
                 <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Guest.IncludeQemuAgent" Label="@L["QEMU Agent"]" ReadOnly="@ReadOnly" />
 
                 <RadzenFormField Text="@L["Agent Timeout sec."]" AllowFloatingLabel="false" class="rz-w-100">
@@ -107,8 +114,8 @@
             </RadzenAccordionItem>
 
             <RadzenAccordionItem Text="@L["Storage"]" Icon="@PveAdminUIHelper.Icons.Storage">
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Storage.IncludeContentSheet" Label="@L["Content Sheet"]" ReadOnly="@ReadOnly" />
-                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Storage.IncludeBackupsSheet" Label="@L["Backups Sheet"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Storage.IncludeContent" Label="@L["Content"]" ReadOnly="@ReadOnly" />
+                <SwitchField Style="margin-bottom: 8px;" @bind-Value="@S.Storage.IncludeBackups" Label="@L["Backups"]" ReadOnly="@ReadOnly" />
                 @RenderRrdData(S.Storage.RrdData)
             </RadzenAccordionItem>
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor
@@ -28,18 +28,13 @@
                      OnRefresh="RefreshDataAsync"
                      DeleteDisabled="!SelectedItems.Any()">
             <TemplateAfter>
-                <RadzenSplitButton Variant="Variant.Text"
-                                   Size="ButtonSize.Small"
-                                   Text="@L["Download"]"
-                                   Icon="download"
-                                   Click="OnDownloadClickAsync"
-                                   Disabled="!SelectedItems.Any() || !SelectedItems[0].End.HasValue"
-                                   IsBusy="InDownload">
-                    <ChildContent>
-                        <RadzenSplitButtonItem Text="@L["Download XLSX"]" Value="xlsx" Icon="table_chart" />
-                        <RadzenSplitButtonItem Text="@L["Download SVG (network diagram)"]" Value="svg" Icon="hub" />
-                    </ChildContent>
-                </RadzenSplitButton>
+                <RadzenButton Variant="Variant.Text"
+                              Size="ButtonSize.Small"
+                              Text="@L["Download"]"
+                              Icon="download"
+                              Click="DownloadAsync"
+                              Disabled="!SelectedItems.Any() || !SelectedItems[0].End.HasValue"
+                              IsBusy="InDownload" />
             </TemplateAfter>
         </CrudToolbar>
     </HeaderTemplate>
@@ -60,5 +55,6 @@
         <DateTimeLocalColumn Property="@nameof(Data.Start)" Title="@L["Start"]" SortOrder="SortOrder.Descending" OrderIndex="0" />
         <DateTimeLocalColumn Property="@nameof(Data.End)" Title="@L["End"]" Visible="false" />
         <RadzenDataGridColumn Property="@nameof(Data.Duration)" Title="@L["Duration"]" FormatString="{0:hh':'mm':'ss'.'fff}" />
+        <RadzenDataGridColumn Property="@nameof(Data.Format)" Title="@L["Format"]" />
     </Columns>
 </RadzenDataGrid>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
@@ -2,13 +2,13 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-using BlazorDownloadFile;
 using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Persistence;
+using Corsinvest.ProxmoxVE.Report;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Components;
 
-public partial class Reports(IBlazorDownloadFileService blazorDownloadFileService,
+public partial class Reports(IBrowserService browserService,
                              IDbContextFactory<ModuleDbContext> dbContextFactory,
                              IBackgroundJobService backgroundJobService,
                              DialogService dialogService,
@@ -27,6 +27,7 @@ public partial class Reports(IBlazorDownloadFileService blazorDownloadFileServic
 
     private record Data(int Id,
                         Report.Settings Settings,
+                        ReportFormat Format,
                         DateTime Start,
                         DateTime? End)
     {
@@ -54,6 +55,7 @@ public partial class Reports(IBlazorDownloadFileService blazorDownloadFileServic
                                                          args,
                                                          a => new Data(a.Id,
                                                                        a.Settings,
+                                                                       a.Format,
                                                                        a.Start,
                                                                        a.End),
                                                          ResultLoadData.Filter);
@@ -89,8 +91,7 @@ public partial class Reports(IBlazorDownloadFileService blazorDownloadFileServic
         {
             await using var db = await dbContextFactory.CreateDbContextAsync();
             var job = (await db.JobResults.FromIdAsync(SelectedItems[0].Id))!;
-            if (File.Exists(job.FileNameXlsx)) { File.Delete(job.FileNameXlsx); }
-            if (File.Exists(job.FileNameSvg)) { File.Delete(job.FileNameSvg); }
+            if (File.Exists(job.FileName)) { File.Delete(job.FileName); }
 
             await db.JobResults.DeleteAsync(SelectedItems[0].Id);
             await eventNotificationService.PublishAsync(new DataChangedNotification());
@@ -106,9 +107,7 @@ public partial class Reports(IBlazorDownloadFileService blazorDownloadFileServic
         else if (e.IsForNew()) { }
     }
 
-    private Task OnDownloadClickAsync(RadzenSplitButtonItem? item) => DownloadAsync(item?.Value!);
-
-    private async Task DownloadAsync(string format)
+    private async Task DownloadAsync()
     {
         InDownload = true;
         try
@@ -116,22 +115,16 @@ public partial class Reports(IBlazorDownloadFileService blazorDownloadFileServic
             await using var db = await dbContextFactory.CreateDbContextAsync();
             var job = (await db.JobResults.FromIdAsync(SelectedItems[0].Id))!;
 
-            var (path, contentType) = format switch
-            {
-                "svg" => (job.FileNameSvg, "image/svg+xml"),
-                _ => (job.FileNameXlsx, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-            };
-
-            if (!File.Exists(path))
+            if (!File.Exists(job.FileName))
             {
                 notificationService.Notify(NotificationSeverity.Warning, L["File not available for this report."]);
                 return;
             }
 
-            await using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
-            await blazorDownloadFileService.DownloadFile($"SystemReport-{job.ClusterName}-{job.Start}.{format}",
-                                                         fileStream,
-                                                         contentType);
+            await using var fileStream = new FileStream(job.FileName, FileMode.Open, FileAccess.Read);
+            await browserService.DownloadFileAsync($"SystemReport-{job.ClusterName}-{job.Start:yyyyMMdd-HHmmss}.zip",
+                                                   fileStream,
+                                                   "application/zip");
         }
         finally
         {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Helpers/ActionHelper.cs
@@ -33,12 +33,14 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 var clusterClient = scope.GetClusterClient(job.ClusterName);
                 var client = await clusterClient.GetPveClientAsync();
 
-                var engine = new ReportEngine(client, job.Settings, new ReportInfo
-                {
-                    ApplicationName = appSettings.AppName,
-                    ApplicationVersion = BuildInfo.Version,
-                    ApplicationUrl = ApplicationHelper.GitHubRepoUrl,
-                });
+                var engine = new ReportEngine(client,
+                                              job.Settings,
+                                              new ReportInfo
+                                              {
+                                                  ApplicationName = appSettings.AppName,
+                                                  ApplicationVersion = BuildInfo.Version,
+                                                  ApplicationUrl = ApplicationHelper.GitHubRepoUrl,
+                                              });
 
                 var disks = await clusterClient.CachedData.GetDiskSnapshotInfosAsync(false);
                 if (disks.Any())
@@ -56,15 +58,10 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                     taskScope.Log(p.ToString());
                 });
 
-                await using var stream = await engine.GenerateAsync(progress);
-                await using (var file = File.Create(job.FileNameXlsx))
+                await using var stream = await engine.GenerateAsync(job.Format, progress);
+                await using (var file = File.Create(job.FileName))
                 {
                     await stream.CopyToAsync(file);
-                }
-
-                if (!string.IsNullOrEmpty(engine.NetworkDiagramSvg))
-                {
-                    await File.WriteAllTextAsync(job.FileNameSvg, engine.NetworkDiagramSvg);
                 }
             }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260510201012_AddReportFormat.Designer.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260510201012_AddReportFormat.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Migrations
 {
     [DbContext(typeof(ModuleDbContext))]
-    partial class ModuleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510201012_AddReportFormat")]
+    partial class AddReportFormat
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260510201012_AddReportFormat.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260510201012_AddReportFormat.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Migrations;
+
+/// <inheritdoc />
+public partial class AddReportFormat : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "Format",
+            schema: "system_reports",
+            table: "JobResults",
+            type: "integer",
+            nullable: false,
+            defaultValue: 0);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Format",
+            schema: "system_reports",
+            table: "JobResults");
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Models/JobResult.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Models/JobResult.cs
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+using Corsinvest.ProxmoxVE.Report;
+
 namespace Corsinvest.ProxmoxVE.Admin.Module.SystemReport.Models;
 
 public class JobResult : JobResultBase, IId, IClusterName
@@ -12,6 +14,7 @@ public class JobResult : JobResultBase, IId, IClusterName
 
     public Report.Settings Settings { get; set; } = Report.Settings.Fast();
 
-    public string FileNameXlsx => Path.Combine(new Module().PathData, $"{Id}.xlsx");
-    public string FileNameSvg => Path.Combine(new Module().PathData, $"{Id}.svg");
+    public ReportFormat Format { get; set; } = ReportFormat.Xlsx;
+
+    public string FileName => Path.Combine(new Module().PathData, $"{Id}.zip");
 }


### PR DESCRIPTION
## Summary

Aligns the SystemReport module with `Corsinvest.ProxmoxVE.Report 2.3.0` (bumped in #295), which now produces a single zip artifact containing the report file in the chosen format, instead of the previous separate `.xlsx` + `.svg` outputs.

## Changes

### `JobResult` model

- Add `Format` property (`ReportFormat` enum from `Corsinvest.ProxmoxVE.Report`), defaulted to `Xlsx` for back-compat with existing records.
- Replace `FileNameXlsx` + `FileNameSvg` with a single `FileName` (`{id}.zip`).

### EF Core migration `AddReportFormat`

Adds an `int Format` column to `system_reports.JobResults` (default `0` = `Xlsx`, matches the back-compat default for existing rows).

### UI

- `ReportDialog`: new format selector (`Xlsx` by default).
- `Reports` grid: surface the chosen format alongside settings, and download the resulting zip via `IBrowserService.DownloadFileAsync`.
- The previous "download split" `RadzenSplitButton` flow is gone — only one artifact is produced now.

### `ActionHelper`

Clean-up and delete now operate on the single `FileName`.

## Test plan

- [ ] CI green
- [ ] Existing reports keep working (default `Format = Xlsx`)
- [ ] New report with format selector: choose format, run, download the resulting `.zip`
- [ ] Delete a report: confirm the single `.zip` is removed from disk

## Depends on

- #295 (Report 1.8.0 → 2.3.0 bump that introduced the single-file/format API)
- #296 (IBrowserService.DownloadFileAsync used by the Reports grid download)