### PR TITLE
fix(build): silence the 4 Release-build warnings (CS8604, IDE0063, CS9107×2)

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Commands/UiCommandExecutor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Commands/UiCommandExecutor.cs
@@ -26,7 +26,7 @@ public class UiCommandExecutor(ICommandExecutor executor,
                                 ? Localizer["Permission denied"].Value
                                 : Localizer["Operation failed"].Value;
 
-            notificationService.Notify(severity, summary, result.ErrorMessage);
+            notificationService.Notify(severity, summary, result.ErrorMessage ?? string.Empty);
         }
         return result;
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetThumbDetailsBase.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Widgets/WidgetThumbDetailsBase.razor.cs
@@ -7,6 +7,9 @@ namespace Corsinvest.ProxmoxVE.Admin.Core.Components.Widgets;
 public abstract partial class WidgetThumbDetailsBase<TWidgetSettings>(IAdminService adminService,
                                                                       ISettingsService settingsService) : IModuleWidget<TWidgetSettings>, IDisposable
 {
+    protected IAdminService AdminService => adminService;
+    protected ISettingsService SettingsService => settingsService;
+
     [Parameter] public TWidgetSettings Settings { get; set; } = default!;
     [Parameter] public EventCallback<TWidgetSettings> SettingsChanged { get; set; }
     [Parameter] public IEnumerable<string> ClusterNames { get; set; } = [];

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/NodesStatus.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/NodesStatus.cs
@@ -15,7 +15,7 @@ public partial class NodesStatus(IAdminService adminService, ISettingsService se
         var countOffline = 0;
         var allOfflineNodes = new List<ClusterResource>();
 
-        foreach (var clusterClient in adminService.GetFrom(ClusterNames))
+        foreach (var clusterClient in AdminService.GetFrom(ClusterNames))
         {
             var nodes = (await clusterClient.CachedData.GetResourcesAsync(false))
                                 .Where(a => a.ResourceType == ClusterResourceType.Node);

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/VmsLocked.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Widgets/VmsLocked.cs
@@ -13,7 +13,7 @@ public partial class VmsLocked(IAdminService adminService, ISettingsService sett
     {
         var allLockedVms = new List<ClusterResource>();
 
-        foreach (var clusterClient in adminService.GetFrom(ClusterNames))
+        foreach (var clusterClient in AdminService.GetFrom(ClusterNames))
         {
             var lockedVms = (await clusterClient.CachedData.GetResourcesAsync(false))
                                 .Where(a => a.ResourceType == ClusterResourceType.Vm && a.IsLocked);

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Helpers/ActionHelper.cs
@@ -59,10 +59,8 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 });
 
                 await using var stream = await engine.GenerateAsync(job.Format, progress);
-                await using (var file = File.Create(job.FileName))
-                {
-                    await stream.CopyToAsync(file);
-                }
+                await using var file = File.Create(job.FileName);
+                await stream.CopyToAsync(file);
             }
 
             job.End = DateTime.UtcNow;


### PR DESCRIPTION
## Summary

The current CI build (Release) emits 4 warnings. None are fatal, but they keep the build log noisy. This PR removes all of them; the next CI run should be silent.

## Warnings & fixes

### `UiCommandExecutor.cs` — CS8604

> Possible null reference argument for parameter 'detail' in 'void NotificationService.Notify(...)'

`NotificationService.Notify`'s `detail` is declared non-null. We were passing `result.ErrorMessage` (nullable). Coalesce with `string.Empty` so we never pass null.

### `SystemReport/Helpers/ActionHelper.cs` — IDE0063

> 'using' statement can be simplified

Collapse the inner `using (var file = File.Create(...))` block into a `using` declaration. One less indent level, identical behaviour.

### `Widgets/NodesStatus.cs` + `Widgets/VmsLocked.cs` — CS9107

> Parameter 'IAdminService adminService' is captured into the state of the enclosing type and its value is also passed to the base constructor.

The two widgets used to take `adminService` as a primary-ctor parameter (captured into the derived type) **and** pass it to the base. The base then also captured it — so we held two copies and the compiler rightly warned about it.

`WidgetThumbDetailsBase` now exposes `AdminService` and `SettingsService` as `protected` properties. The two widgets stop touching their local `adminService` parameter and read it from the base property instead. Same behaviour, one capture instead of two, warning gone.

## Build

Local Release build (CE): **0 warnings, 0 errors**.

## Test plan

- [ ] CI Release build green and silent (no warnings)
- [ ] NodesStatus / VmsLocked widgets still render the expected counts on the dashboard