### PR TITLE
chore: dotnet format --severity info pass over the codebase

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor.cs
@@ -41,7 +41,7 @@ public partial class StorageContents<TItem> where TItem : NodeStorageContent
         if (args.FirstRender) { args.Expanded = false; }
     }
 
-    private string GetGroupHeader(Group group)
+    private static string GetGroupHeader(Group group)
         => group.Data.Items != null
             ? FormatHelper.FromBytes(group.Data.Items!.Cast<NodeStorageContent>().Sum(a => a.Size))
             : string.Empty;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Services;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Components;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Models;
 using Corsinvest.ProxmoxVE.Admin.Module.NodeProtect.Persistence;
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Migrations/20260221112216_AddAppTokens.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Migrations/20260221112216_AddAppTokens.cs
@@ -97,7 +97,7 @@ public partial class AddAppTokens : Migration
             name: "IX_AppTokenPermissions_AppTokenId_PermissionKey_Path_ClusterNa~",
             schema: "system",
             table: "AppTokenPermissions",
-            columns: new[] { "AppTokenId", "PermissionKey", "Path", "ClusterName" });
+            columns: ["AppTokenId", "PermissionKey", "Path", "ClusterName"]);
 
         migrationBuilder.CreateIndex(
             name: "IX_AppTokenRoles_RoleId",

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Service/TaskTrackerService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Service/TaskTrackerService.cs
@@ -181,8 +181,8 @@ internal class TaskTrackerService(IDbContextFactory<ModuleDbContext> dbContextFa
     private async Task PersistOnCompletionAsync(int id, TaskScope scope)
     {
         var tcs = new TaskCompletionSource();
-        Action onUpdate = () => _ = FlushLogsAsync(id, scope);
-        Action onEnd = () => tcs.TrySetResult();
+        void onUpdate() => _ = FlushLogsAsync(id, scope);
+        void onEnd() => tcs.TrySetResult();
 
         scope.Item.Updated += onUpdate;
         scope.Item.TaskEnded += onEnd;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260330201858_ReplaceFieldsWithSettingsJson.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Migrations/20260330201858_ReplaceFieldsWithSettingsJson.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Net.Mime;
-using Corsinvest.ProxmoxVE.Admin.Core.Services;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Helpers;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Models;
 using Corsinvest.ProxmoxVE.Admin.Module.Updater.Services;


### PR DESCRIPTION
## Summary

Ran `dotnet format --severity info` on the CE solution. Out of ~370 files processed, only **7** ended up with non-whitespace changes; the rest were already compliant with the `.editorconfig`.

Total churn: **5 insertions, 8 deletions** across 7 files.

## Changes

| File | Rule | What |
|---|---|---|
| `Core/Components/ProxmoxVE/Nodes/StorageContents.razor.cs` | CA1822 | `GetGroupHeader` doesn't touch instance state → marked `static` |
| `Diagnostic/Components/Scans.razor.cs` | IDE0005 | Removed unused `using Corsinvest.ProxmoxVE.Admin.Core.Services;` (covered by `GlobalUsings`) |
| `NodeProtect/Folder/Components/Render.razor.cs` | IDE0005 | Same — unused using |
| `Updater/Components/Scans.razor.cs` | IDE0005 | Same — unused using |
| `System/TaskTracking/Service/TaskTrackerService.cs` | IDE0039 | `Action onUpdate = () => ...` → local function `void onUpdate() => ...` (no delegate allocation) |
| `System/Migrations/20260221112216_AddAppTokens.cs` | IDE0028 | EF-generated `new[] { ... }` → collection expression `[ ... ]` |
| `SystemReport/Migrations/20260330201858_ReplaceFieldsWithSettingsJson.cs` | encoding | Removed a stray UTF-8 BOM (the only file with one in that folder) |

## Build

Release build remains **0 warnings, 0 errors**.

## Test plan

- [ ] CI green
- [ ] No behavioural change expected; this is style-only