### PR TITLE
feat(tasks): auto-ack failed tasks on menu open + refine Active filter

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/ActiveTasksMenu.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/Layout/ActiveTasksMenu.razor.cs
@@ -31,6 +31,17 @@ public partial class ActiveTasksMenu(ContextMenuService contextMenuService,
     {
         args.ClientY += 24;
         contextMenuService.Open(args, _ => RenderPanel);
+
+        var unackedErrorIds = await taskTracker.GetRecentAsync(
+            _principal!,
+            a => a.Id,
+            filter: t => !t.IsAcknowledged &&
+                         (t.Status == TaskItemStatus.Failed || t.Status == TaskItemStatus.Abandoned));
+
+        if (unackedErrorIds.Count > 0)
+        {
+            await taskTracker.AcknowledgeAsync(unackedErrorIds);
+        }
     }
 
     private void OnChanged(object? sender, TaskItem e) => RefreshBadge();

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/TaskTracking/TaskItemFilters.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/TaskTracking/TaskItemFilters.cs
@@ -8,10 +8,8 @@ namespace Corsinvest.ProxmoxVE.Admin.Core.TaskTracking;
 
 public static class TaskItemFilters
 {
-    /// <summary>
-    /// Matches tasks that are not completed or ended within the last hour.
-    /// </summary>
     public static readonly Expression<Func<TaskItem, bool>> Active = t =>
-        t.Status != TaskItemStatus.Completed &&
-        (t.EndedAt == null || t.EndedAt >= DateTime.UtcNow.AddHours(-1));
+        t.Status == TaskItemStatus.Running
+        || (t.EndedAt != null && t.EndedAt >= DateTime.UtcNow.AddMinutes(-10))
+        || ((t.Status == TaskItemStatus.Failed || t.Status == TaskItemStatus.Abandoned) && !t.IsAcknowledged);
 }


### PR DESCRIPTION
## Summary

- **Auto-acknowledge on open**: opening the Active Tasks menu now marks all unacknowledged failed/abandoned tasks as acknowledged. The badge clears after the user has actually seen the errors, instead of staying red forever or being silently swept.
- **Explicit Active filter**: the filter is rewritten to be predicate-by-predicate readable:
  - Running tasks (always visible)
  - Recently ended tasks (last **10 minutes**, was 1 hour)
  - Unacknowledged failures/abandons (regardless of age — these stay until ack)

## Test plan

- [ ] Run a job that fails → badge increments
- [ ] Open Active Tasks menu → failed task visible, badge stays
- [ ] Close and reopen menu → badge cleared (auto-ack happened on first open)
- [ ] Run a successful job → appears in menu, disappears after 10 min
- [ ] Run a job and abandon it → behaves like failure (visible until acked)