### PR TITLE
chore: bump packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,12 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Corsinvest.ProxmoxVE.NodeProtect.Api" Version="2.1.1" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="2.3.0" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="2.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="6.2.1" />
@@ -28,7 +28,7 @@
   </ItemGroup>
   <!-- UI and Frontend -->
   <ItemGroup>
-    <PackageVersion Include="Radzen.Blazor" Version="10.4.3" />
+    <PackageVersion Include="Radzen.Blazor" Version="10.4.6" />
     <PackageVersion Include="OpenLayers.Blazor" Version="2.5.0" />
   </ItemGroup>
   <!-- Utilities and Tools -->
@@ -45,10 +45,10 @@
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
     <!-- 3.1.12: latest 3.x (Apache-2.0) with all known CVEs fixed.
          DO NOT upgrade to v4.x: switched to Six Labors Split License (commercial). -->
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.12]" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageVersion Include="MailKit" Version="4.16.0" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
   <!-- Scheduling and Background Jobs -->
@@ -61,11 +61,11 @@
   </ItemGroup>
   <!-- Proxmox VE -->
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.18" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.TelegramBot.Api" Version="1.9.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Metrics.Exporter.Api" Version="2.0.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.AutoSnap.Api" Version="2.1.1" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Diagnostic.Api" Version="2.2.4" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Diagnostic.Api" Version="2.3.0" />
   </ItemGroup>
   <!-- Development and Code Quality -->
   <ItemGroup>

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Library updates across `Directory.Packages.props` and AppHost csproj:

- Aspire.Hosting.* 13.3.4 → 13.3.5
- Corsinvest.ProxmoxVE.Api.Extension 9.1.18 → 9.2.0
- Corsinvest.ProxmoxVE.Diagnostic.Api 2.2.4 → 2.3.0
- Corsinvest.ProxmoxVE.Report 2.3.0 → 2.5.0
- MailKit 4.16.0 → 4.17.0
- Npgsql.EntityFrameworkCore.PostgreSQL 10.0.1 → 10.0.2
- Radzen.Blazor 10.4.3 → 10.4.6
- SixLabors.ImageSharp pinned to exact `[3.1.12]` (prevents accidental v4 upgrade — v4 switched to the Six Labors Split License, commercial)

## Test plan

- [x] `dotnet build cv4pve-admin.sln` → 0 warnings, 0 errors
- [ ] Smoke-test the app boots and the Aspire dashboard renders