### PR TITLE
feat(diagnostic): real PDF + Excel export in CE, dropdown UI

### DIFF
--- a/docs/user/docs/editions.md
+++ b/docs/user/docs/editions.md
@@ -71,7 +71,7 @@ This section outlines the current development status of upcoming and evolving mo
 | **[Bots](modules/bots.md)** | ✅ | ✅ | Control | Remote cluster management via Telegram | |
 | **[Command Palette](modules/command-palette.md)** | ✅ | ✅ | Application | Quick access to commands and navigation (Ctrl+K / Cmd+K) | <ul><li>Additional enterprise commands for user management, subscriptions, and workflow</li></ul> |
 | **[Dashboard](modules/dashboard.md)** | ✅ | ✅ | Utilities | Customizable dashboards with widgets and metrics | <ul><li>Additional widgets from Enterprise modules</li></ul> |
-| **[Diagnostics](modules/diagnostics.md)** | ✅ | ✅ | Health | Infrastructure diagnostics and health checks | <ul><li>Help links to Proxmox documentation for each issue</li><li>PDF export of diagnostic report</li></ul> |
+| **[Diagnostics](modules/diagnostics.md)** | ✅ | ✅ | Health | Infrastructure diagnostics, health checks and report export (PDF + Excel) | <ul><li>Executive Summary on PDF (counts per gravity + top critical issues)</li></ul> |
 | **[Metrics Exporter](modules/metrics-exporter.md)** | ✅ | ✅ | Health | Exposes Proxmox VE metrics for monitoring systems (Prometheus) | |
 | **[Node Protect](modules/node-protect.md)** | ✅ | ✅ | Protection | Node configuration backup | <ul><li>Git provider integration with automatic push</li></ul> |
 | **[Notifier](configuration/notifier.md)** | ✅ | ✅ | Notification | Notification system (CE: Email only) | <ul><li>119 services (Telegram, Discord, Slack, Teams, and more...)</li></ul> |
@@ -92,7 +92,6 @@ These are optional add-on modules available exclusively for Enterprise Edition, 
 | **[Portal](modules/portal.md)** | ✅ | Management | Multi-tenant MSP portal with role-based access control (RBAC) for service providers |
 | **[Workflow](modules/workflow.md)** | 🚧 | Automation | Visual workflow designer with 30+ Proxmox-specific activities for advanced automation |
 | **DDR** | 📐 | Protection | Disaster Recovery orchestration with Ceph RBD Mirror support (Alpha) |
-| **[DRS](modules/drs.md)** | 🚧 | Automation | Distributed Resource Scheduler for intelligent VM load balancing |
 
 ---
 

--- a/docs/user/docs/modules/diagnostics.md
+++ b/docs/user/docs/modules/diagnostics.md
@@ -44,4 +44,22 @@ Performs health checks and analysis of Proxmox VE environments. Scans clusters, 
 
     Displays issue descriptions with resolution recommendations.
 
+-   :material-download:{ .lg .middle } **Export Reports**
+
+    ---
+
+    Download scan results as **PDF** (issues table colored by gravity, ignored issues section, footer) or **Excel** (autofilter-enabled sheet for slicing/pivoting). Format chosen from a split-button dropdown on the Scans page.
+
+-   :material-link-variant:{ .lg .middle } **Help Links**
+
+    ---
+
+    Each issue can link to the relevant Proxmox documentation page (e.g. Qemu Guest Agent, VirtIO drivers, end-of-life OS tracking).
+
+-   :material-chart-box:{ .lg .middle } **Executive Summary** <span class="ee"></span>
+
+    ---
+
+    Enterprise PDF adds a one-page Executive Summary at the top: issue counts by gravity (Critical / Warning / Info) and the top 5 critical issues — useful for management or MSP customer reports.
+
 </div>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/RenderSettings.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/RenderSettings.razor
@@ -148,6 +148,7 @@
                         @RenderThreshold(L["Usage"], "Model.ApiSettings.Storage.Threshold", Model.ApiSettings.Storage.Threshold)
                     </RadzenColumn>
                 </RadzenRow>
+                @RenderPsiPressure(Model.ApiSettings.Storage.Rrd, "Model.ApiSettings.Storage.Rrd")
             </RadzenAccordionItem>
 
             <RadzenAccordionItem Text="@L["Snapshot"]" Icon="camera_alt">

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor
@@ -33,13 +33,18 @@
             </TemplateBefore>
 
             <TemplateAfter>
-                <RadzenButton Variant="Variant.Text"
-                              Size="ButtonSize.Small"
-                              Text="@L["Download PDF"]"
-                              Click="DownloadAsync"
-                              Icon="download"
-                              Disabled="!SelectedItems.Any()"
-                              IsBusy="InDownload" />
+                <RadzenSplitButton Variant="Variant.Text"
+                                   Size="ButtonSize.Small"
+                                   Text="@L["Download"]"
+                                   Icon="download"
+                                   Disabled="!SelectedItems.Any()"
+                                   IsBusy="InDownload"
+                                   Click="@(args => DownloadAsync(args))">
+                    <ChildContent>
+                        <RadzenSplitButtonItem Text="PDF" Icon="picture_as_pdf" Value="@nameof(ReportFormat.Pdf)" />
+                        <RadzenSplitButtonItem Text="Excel" Icon="table_view" Value="@nameof(ReportFormat.Excel)" />
+                    </ChildContent>
+                </RadzenSplitButton>
 
                 <InfoScheduler TModule="Module" JobSchedule="@Settings" />
             </TemplateAfter>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -107,14 +107,28 @@ public partial class Scans(IBrowserService browserService,
         else if (e.IsForNew()) { }
     }
 
-    private async Task DownloadAsync()
+    private async Task DownloadAsync(RadzenSplitButtonItem? item)
     {
+        var format = item?.Value switch
+        {
+            nameof(ReportFormat.Excel) => ReportFormat.Excel,
+            _ => ReportFormat.Pdf,
+        };
+
         InDownload = true;
 
         await using var db = await dbContextFactory.CreateDbContextAsync();
         var result = (await db.JobResults.Include(a => a.Details).FromIdAsync(SelectedItems[0].Id))!;
-        await using var ms = diagnosticService.GeneratePdf(result);
-        await browserService.DownloadFileAsync($"Diagnostic-{result.ClusterName}-{result.Start}.pdf", ms, MediaTypeNames.Application.Pdf);
+        await using var ms = diagnosticService.GenerateReport(result, format);
+
+        var (extension, contentType) = format switch
+        {
+            ReportFormat.Pdf => ("pdf", MediaTypeNames.Application.Pdf),
+            ReportFormat.Excel => ("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+            _ => throw new ArgumentOutOfRangeException(nameof(format)),
+        };
+
+        await browserService.DownloadFileAsync($"Diagnostic-{result.ClusterName}-{result.Start:yyyyMMddHHmmss}.{extension}", ms, contentType);
 
         InDownload = false;
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Helpers/ActionHelper.cs
@@ -99,7 +99,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 {
                     var diagnosticService = scope.GetRequiredService<IDiagnosticService>();
 
-                    await using var ms = diagnosticService.GeneratePdf(new JobResult
+                    await using var ms = diagnosticService.GenerateReport(new JobResult
                     {
                         ClusterName = clusterName,
                         Start = now,
@@ -107,7 +107,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                         Critical = Count(DiagnosticResultGravity.Critical),
                         Info = Count(DiagnosticResultGravity.Info),
                         Warning = Count(DiagnosticResultGravity.Warning)
-                    });
+                    }, ReportFormat.Pdf);
 
                     var appSettings = scope.GetSettingsService().GetAppSettings();
                     var L = scope.GetRequiredService<IStringLocalizer<ActionHelper>>();

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/DiagnosticService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/DiagnosticService.cs
@@ -2,12 +2,270 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+using Corsinvest.ProxmoxVE.Admin.Core.Exporters.Excel;
+using Corsinvest.ProxmoxVE.Diagnostic.Api;
+using MigraDoc.DocumentObjectModel;
+using MigraDoc.DocumentObjectModel.Tables;
+using MigraDoc.Rendering;
+using MigraDocColors = MigraDoc.DocumentObjectModel.Colors;
+
 namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Services;
 
-internal class DiagnosticService(IReportService reportService, IStringLocalizer<DiagnosticService> L) : IDiagnosticService
+public class DiagnosticService(IStringLocalizer<DiagnosticService> L, ISettingsService settingsService) : IDiagnosticService
 {
-    public MemoryStream GeneratePdf(JobResult result)
-        => reportService.GeneratePdf(L["Diagnostic result of cluster '{0}' Date {1}", result.ClusterName, result.Start]);
+    protected IStringLocalizer L { get; } = L;
+    protected ISettingsService SettingsService { get; } = settingsService;
 
-    public string GetHelpUrl(JobDetail jobDetail) => string.Empty;
+    public virtual string GetHelpUrl(JobDetail jobDetail)
+    {
+        var url = string.Empty;
+        switch (jobDetail.Context)
+        {
+            case DiagnosticResultContext.Node:
+                switch (jobDetail.SubContext)
+                {
+                    case "EOL": url = "https://pve.proxmox.com/wiki/FAQ"; break;
+                    default: break;
+                }
+                break;
+
+            case DiagnosticResultContext.Cluster: break;
+            case DiagnosticResultContext.Storage: break;
+
+            case DiagnosticResultContext.Qemu:
+                switch (jobDetail.SubContext)
+                {
+                    case "Agent": url = "https://pve.proxmox.com/wiki/Qemu-guest-agent"; break;
+
+                    case "OSNotMaintained":
+                        if (jobDetail.Description.Contains("Windows"))
+                        {
+                            url = "https://endoflife.date/windows";
+                        }
+                        else if (jobDetail.Description.Contains("Linux"))
+                        {
+                            url = "https://endoflife.date/linux";
+                        }
+                        break;
+
+                    case "VirtIO":
+                        if (jobDetail.Description.Contains("network"))
+                        {
+                            url = "https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_network_device";
+                        }
+                        break;
+
+                    case "StartOnBoot":
+                        url = "https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_startup_and_shutdown";
+                        break;
+
+                    default: break;
+                }
+                break;
+
+            case DiagnosticResultContext.Lxc: break;
+
+            default: break;
+        }
+
+        return url;
+    }
+
+    public Stream GenerateReport(JobResult result, ReportFormat format)
+        => format switch
+        {
+            ReportFormat.Pdf => GeneratePdf(result),
+            ReportFormat.Excel => GenerateExcel(result),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
+        };
+
+    protected virtual MemoryStream GeneratePdf(JobResult result)
+    {
+        var document = new Document();
+        var section = CreateSection(document);
+
+        AddTitle(section, result);
+        AddIssuesSection(section, result);
+        AddFooter(section);
+
+        return Render(document);
+    }
+
+    protected virtual Stream GenerateExcel(JobResult result)
+    {
+        var builder = new ExcelBuilder(SettingsService.GetAppSettings());
+
+        AddIssuesSheet(builder, result);
+
+        return builder.Build(L["Diagnostic result of cluster '{0}' Date {1}", result.ClusterName, result.Start]);
+    }
+
+    protected void AddIssuesSheet(ExcelBuilder builder, JobResult result)
+    {
+        var rows = result.Details.OrderBy(a => a.Gravity)
+                                 .ThenBy(a => a.IdResource)
+                                 .Select(a => new
+                                 {
+                                     Id = a.IdResource,
+                                     Context = a.Context.ToString(),
+                                     SubContext = a.SubContext ?? string.Empty,
+                                     a.Description,
+                                     Gravity = a.Gravity.ToString(),
+                                     IsIgnored = a.IsIgnoredIssue,
+                                 });
+
+        builder.AddSheet("Issues", L["All diagnostic issues found"], rows);
+    }
+
+    protected Section CreateSection(Document document)
+    {
+        var section = document.AddSection();
+        section.PageSetup.PageFormat = PageFormat.A4;
+        section.PageSetup.TopMargin = Unit.FromMillimeter(10);
+        section.PageSetup.BottomMargin = Unit.FromMillimeter(20);
+        section.PageSetup.LeftMargin = Unit.FromMillimeter(10);
+        section.PageSetup.RightMargin = Unit.FromMillimeter(10);
+        return section;
+    }
+
+    protected void AddTitle(Section section, JobResult result)
+    {
+        var title = section.AddParagraph();
+        title.AddFormattedText(L["Diagnostic result of cluster '{0}' Date {1}", result.ClusterName, result.Start], TextFormat.Bold);
+        title.Format.Font.Size = 14;
+        title.Format.SpaceAfter = Unit.FromMillimeter(5);
+    }
+
+    protected void AddIssuesSection(Section section, JobResult result)
+    {
+        AddResultsTable(section, result.Details.Where(a => !a.IsIgnoredIssue));
+
+        var ignoredIssues = result.Details.Where(a => a.IsIgnoredIssue).ToList();
+        if (ignoredIssues.Count != 0)
+        {
+            section.AddPageBreak();
+            var ignoredTitle = section.AddParagraph(L["Ignored"]);
+            ignoredTitle.Format.Font.Size = 16;
+            ignoredTitle.Format.Font.Bold = true;
+            ignoredTitle.Format.SpaceAfter = Unit.FromMillimeter(5);
+            AddResultsTable(section, ignoredIssues);
+        }
+    }
+
+    protected void AddFooter(Section section)
+    {
+        var appSettings = SettingsService.GetAppSettings();
+
+        var footer = section.Footers.Primary.AddTable();
+        footer.Borders.Visible = false;
+
+        var totalAvailableWidth = Unit.FromCentimeter(19);
+
+        footer.AddColumn(totalAvailableWidth / 2);
+        footer.AddColumn(totalAvailableWidth / 2);
+
+        var row = footer.AddRow();
+        row.TopPadding = 3;
+
+        var leftCell = row.Cells[0];
+        leftCell.Format.Alignment = ParagraphAlignment.Left;
+        var datePara = leftCell.AddParagraph();
+        datePara.AddText(DateTime.Now.ToString("dd/MM/yyyy") + " - " + L["Page"] + " ");
+        datePara.AddPageField();
+        datePara.AddText(" " + L["of"] + " ");
+        datePara.AddNumPagesField();
+        datePara.Format.Font.Size = 10;
+
+        var rightCell = row.Cells[1];
+        rightCell.Format.Alignment = ParagraphAlignment.Right;
+
+        var poweredPara = rightCell.AddParagraph();
+        poweredPara.Format.Alignment = ParagraphAlignment.Right;
+        poweredPara.AddText("Powered by ");
+        poweredPara.Format.Font.Size = 10;
+
+        var hyperlink = poweredPara.AddHyperlink(appSettings.AppUrl, HyperlinkType.Web);
+        hyperlink.AddText(appSettings.AppName);
+        hyperlink.Font.Underline = Underline.Single;
+        hyperlink.Font.Color = MigraDocColors.Blue;
+        hyperlink.Font.Size = 10;
+    }
+
+    protected static MemoryStream Render(Document document)
+    {
+        var pdfRenderer = new PdfDocumentRenderer { Document = document };
+        pdfRenderer.RenderDocument();
+        var ms = new MemoryStream();
+        pdfRenderer.PdfDocument.Save(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        return ms;
+    }
+
+    private void AddResultsTable(Section section, IEnumerable<JobDetail> results)
+    {
+        var table = section.AddTable();
+        table.Borders.Width = 0.5;
+        table.Format.Font.Size = 9;
+
+        var totalAvailableWidth = Unit.FromCentimeter(19);
+
+        // Wider Id column so long IDs like "access/user/cv4pve-admin@pve" wrap inside the cell
+        // instead of overflowing onto the next column.
+        table.AddColumn(totalAvailableWidth * 0.22);
+        table.AddColumn(totalAvailableWidth * 0.13);
+        table.AddColumn(totalAvailableWidth * 0.15);
+        table.AddColumn(totalAvailableWidth * 0.42);
+        table.AddColumn(totalAvailableWidth * 0.08);
+
+        var headerRow = table.AddRow();
+        headerRow.Shading.Color = MigraDocColors.LightGray;
+        headerRow.Cells[0].AddParagraph(L["Id"]);
+        headerRow.Cells[1].AddParagraph(L["Context"]);
+        headerRow.Cells[2].AddParagraph(L["SubContext"]);
+        headerRow.Cells[3].AddParagraph(L["Description"]);
+        headerRow.Cells[4].AddParagraph(L["Gravity"]);
+        headerRow.Format.Font.Bold = true;
+
+        foreach (var item in results.OrderBy(a => a.Gravity).ThenBy(a => a.IdResource))
+        {
+            var row = table.AddRow();
+            AddBreakableText(row.Cells[0], item.IdResource);
+            row.Cells[1].AddParagraph(item.Context.ToString());
+            row.Cells[2].AddParagraph(item.SubContext ?? string.Empty);
+            row.Cells[3].AddParagraph(item.Description ?? string.Empty);
+            var cell = row.Cells[4];
+            cell.AddParagraph(item.Gravity.ToString());
+            cell.Format.Font.Color = item.Gravity switch
+            {
+                DiagnosticResultGravity.Info => MigraDocColors.Black,
+                DiagnosticResultGravity.Warning => MigraDocColors.Orange,
+                DiagnosticResultGravity.Critical => MigraDocColors.Red,
+                _ => cell.Format.Font.Color
+            };
+        }
+    }
+
+    // MigraDoc breaks paragraphs only at whitespace. Long tokens like
+    // "access/user/cv4pve-admin@pve" have no spaces and overflow the cell.
+    // Insert zero-width spaces after every separator so the renderer can wrap.
+    private static void AddBreakableText(Cell cell, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            cell.AddParagraph(string.Empty);
+            return;
+        }
+
+        const char zws = '​';
+        var withBreaks = new System.Text.StringBuilder(text.Length * 2);
+        foreach (var ch in text)
+        {
+            withBreaks.Append(ch);
+            if (ch is '/' or '\\' or '.' or '@' or '-' or '_' or ':')
+            {
+                withBreaks.Append(zws);
+            }
+        }
+        cell.AddParagraph(withBreaks.ToString());
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/ReportFormat.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/ReportFormat.cs
@@ -4,8 +4,8 @@
  */
 namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Services;
 
-public interface IDiagnosticService
+public enum ReportFormat
 {
-    Stream GenerateReport(JobResult result, ReportFormat format);
-    string GetHelpUrl(JobDetail jobDetail);
+    Pdf,
+    Excel,
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/_Imports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/_Imports.razor
@@ -14,3 +14,4 @@
 @using Corsinvest.ProxmoxVE.Admin.Core.Components.DataGrid
 @using Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Models
 @using Corsinvest.ProxmoxVE.Admin.Core.Components.ProxmoxVE
+@using Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Services


### PR DESCRIPTION
## Summary

CE used to generate a placeholder PDF (just the title and a "Get Enterprise" upsell) — clicking Export was misleading. CE now produces a real, useful report; the EE add becomes a real differentiator.

### What's in CE now

- **PDF**: title, full issues table colored by gravity, ignored issues section on its own page, footer with date/page numbers and "Powered by AppName".
- **Excel**: built on top of the existing `ExcelBuilder` (cover sheet + "Issues" sheet with autofilter).
- **Help links**: `GetHelpUrl` returns the actual Proxmox documentation URLs that used to be EE-only (Qemu Guest Agent, VirtIO drivers, end-of-life OS, etc.).
- **Settings UI**: PSI Pressure accordion now also exposed for Storage (was missing).

### API change

- New `ReportFormat` enum (Pdf, Excel) + single `Stream GenerateReport(JobResult, ReportFormat)` on `IDiagnosticService` (matches the `SystemReport` convention — easy to extend to CSV/JSON/HTML later).
- `DiagnosticService` is now `public` with `protected virtual` hooks so the EE service can extend the PDF (Executive Summary, top critical issues).

### UI

- Scans page replaces the single "Download PDF" button with a `RadzenSplitButton`:
  - Primary click → PDF (default, preserves the current UX)
  - Dropdown → PDF / Excel

### Docs

- `modules/diagnostics.md` — new cards for Export Reports, Help Links, and Executive Summary (badge EE).
- `editions.md` — the Diagnostics row now lists PDF + Excel export as CE features; only the Executive Summary remains EE-only.

## Test plan

- [ ] Run a Diagnostic scan
- [ ] Open Scans → select a row → click **Download** → PDF downloads with real content (not the upsell page)
- [ ] Click the chevron → choose **Excel** → `.xlsx` downloads with a Cover sheet + Issues sheet, autofilter works
- [ ] Open a critical issue's help link → lands on the right Proxmox docs page
- [ ] Open Diagnostic Settings → Storage accordion shows PSI Pressure thresholds