### PR TITLE
chore: enqueue manual scan jobs immediately, drop 5s delay

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
@@ -124,7 +124,7 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
 
     private void Scan()
     {
-        backgroundJobService.Schedule<Job>(a => a.ScanAsync(ClusterName), TimeSpan.FromSeconds(5));
+        backgroundJobService.Enqueue<Job>(a => a.ScanAsync(ClusterName));
         notificationService.Info(L["Scan started!"]);
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -135,7 +135,7 @@ public partial class Scans(IBrowserService browserService,
 
     private void Scan()
     {
-        backgroundJobService.Schedule<Job>(a => a.ScanAsync(ClusterName), TimeSpan.FromSeconds(5));
+        backgroundJobService.Enqueue<Job>(a => a.ScanAsync(ClusterName));
         notificationService.Info(L["Scan started!"]);
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
@@ -102,7 +102,7 @@ public partial class Render(IDbContextFactory<ModuleDbContext> dbContextFactory,
 
     private void Backup()
     {
-        backgroundJobService.Schedule<Job>(a => a.BackupAsync(ClusterName), TimeSpan.FromSeconds(5));
+        backgroundJobService.Enqueue<Job>(a => a.BackupAsync(ClusterName));
         notificationService.Info(L["Backup started!"]);
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
@@ -86,7 +86,7 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
 
     private void Scan()
     {
-        backgroundJobService.Schedule<Job>(a => a.ScanAsync(ClusterName), TimeSpan.FromSeconds(5));
+        backgroundJobService.Enqueue<Job>(a => a.ScanAsync(ClusterName));
         notificationService.Info(L["Scan started!"]);
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
@@ -146,7 +146,7 @@ public partial class Reports(IBrowserService browserService,
             await db.JobResults.AddAsync(item);
             await db.SaveChangesAsync();
 
-            backgroundJobService.Schedule<Job>(a => a.GenerateAsync(item.Id), TimeSpan.FromSeconds(5));
+            backgroundJobService.Enqueue<Job>(a => a.GenerateAsync(item.Id));
             notificationService.Info(L["Report started!"]);
 
             await DataGridRef.Reload();


### PR DESCRIPTION
## Summary

Manual click of **Scan / Backup / Generate** on five modules wrapped the call in `Schedule<Job>(..., TimeSpan.FromSeconds(5))`. The user clicked, got a "Scan started" toast, but the job actually waited 5 seconds before running — pointless delay, surprising on debugging.

Use `Enqueue<Job>(...)` so the work starts immediately:

- BackupAnalytics → Scan
- Diagnostic → Scan
- NodeProtect (Folder) → Backup
- ReplicationAnalytics → Scan
- SystemReport → Generate

Same change Updater got in PR #306. Cron-scheduled jobs are unaffected (they go through `ScheduleOrRemove` with the user's cron expression).

## Test plan

- [ ] Click Scan/Backup/Generate on each of the 5 modules → task starts immediately in the task tracker (no 5s gap between toast and progress)