### PR TITLE
chore(core): a few Core fixes

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CopyToClipboardButton.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CopyToClipboardButton.razor
@@ -14,12 +14,19 @@
               aria-label="@L["Copy to clipboard"]" />
 
 @code {
-    [Parameter, EditorRequired] public string Text { get; set; } = default!;
+    [Parameter] public Func<string>? TextProvider { get; set; }
+    [Parameter] public Func<Task<string>>? TextProviderAsync { get; set; }
     [Parameter] public bool ShowNotification { get; set; } = true;
 
     private async Task CopyAsync()
     {
-        await BrowserService.CopyToClipboardAsync(Text);
+        var text = TextProviderAsync is not null
+                            ? await TextProviderAsync()
+                            : TextProvider?.Invoke();
+
+        if (text is null) { return; }
+
+        await BrowserService.CopyToClipboardAsync(text);
         if (ShowNotification) { NotificationService.Success(L["Copied!"]); }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CopyValueDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/CopyValueDialog.razor
@@ -15,7 +15,7 @@
             <RadzenTextBox Value="@Value" Style="font-family:monospace; width:100%" ReadOnly="true" />
         </ChildContent>
         <End>
-            <CopyToClipboardButton Text="@Value" />
+            <CopyToClipboardButton TextProvider="@(() => Value)" />
         </End>
     </RadzenFormField>
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Configuration/ClusterSettings.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Configuration/ClusterSettings.cs
@@ -10,7 +10,7 @@ namespace Corsinvest.ProxmoxVE.Admin.Core.Configuration;
 public class ClusterSettings : IName, IDescription, IEnabled, IValidatableObject
 {
     [Required] public string Name { get; set; } = default!;
-    [Required] public string PveName { get; set; } = default!;
+    public string PveName { get; set; } = default!;
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public ClusterType Type { get; set; } = default!;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Services/PermissionService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Services/PermissionService.cs
@@ -85,18 +85,23 @@ public class PermissionService(ICurrentUserService currentUserService,
                                            TimeSpan.FromMinutes(10),
                                            tags: [CacheTag]);
 
-    public async Task<List<RolePermission>> GetRolePermissionsAsync(string roleId)
-        => await fusionCache.GetOrSetAsync($"Permissions:RolePermissions:{roleId}",
-                                           async token =>
-                                           {
-                                               await using var db = await dbContextFactory.CreateDbContextAsync(token);
+    private ValueTask<Dictionary<string, List<RolePermission>>> GetAllRolePermissionsAsync()
+        => fusionCache.GetOrSetAsync("Permissions:AllRolePermissions",
+                                     async token =>
+                                     {
+                                         await using var db = await dbContextFactory.CreateDbContextAsync(token);
 
-                                               return await db.RolePermissions.AsNoTracking()
-                                                                              .Where(a => a.RoleId == roleId)
-                                                                              .ToListAsync(token);
-                                           },
-                                           TimeSpan.FromMinutes(10),
-                                           tags: [CacheTag]);
+                                         var all = await db.RolePermissions.AsNoTracking().ToListAsync(token);
+                                         return all.GroupBy(a => a.RoleId).ToDictionary(g => g.Key, g => g.ToList());
+                                     },
+                                     TimeSpan.FromMinutes(10),
+                                     tags: [CacheTag]);
+
+    public async Task<List<RolePermission>> GetRolePermissionsAsync(string roleId)
+    {
+        var all = await GetAllRolePermissionsAsync();
+        return all.TryGetValue(roleId, out var list) ? list : [];
+    }
 
     public async Task<bool> HasAnyAsync(string userId,
                                         string clusterName,
@@ -255,7 +260,7 @@ public class PermissionService(ICurrentUserService currentUserService,
 
     private async Task InvalidateRolePermissionsAsync(string roleId)
     {
-        await fusionCache.RemoveAsync($"Permissions:RolePermissions:{roleId}");
+        await fusionCache.RemoveAsync("Permissions:AllRolePermissions");
         await fusionCache.RemoveAsync("Permissions:RolesClaims");
     }
 


### PR DESCRIPTION
## Summary

Three small, independent Core fixes:

### 1. `PermissionService` — fix N+1 query causing connection-pool starvation

`GetRolePermissionsAsync` used to run **one DB query per role**, cached with a per-role FusionCache key. Under load (rendering a page with many `<PermissionView>` and an admin user holding ~20 built-in roles) this fanned out to ~20 concurrent factory executions per `HasAsync` call, each opening its own `DbContext` and connection. On busy installations the Npgsql pool saturated and the UI froze for 10+ seconds.

The cache now holds the **full** `Dictionary<RoleId, List<RolePermission>>` built from a **single** query. `GetRolePermissionsAsync` is a constant-time dictionary lookup. `InvalidateRolePermissionsAsync` drops the single cache entry.

### 2. `ClusterSettings.PveName` — drop `[Required]`

`PveName` is **not user input** — it is filled by `PopulateClusterSettingsAsync` after the form is submitted (talking to the PVE cluster to read its real name). Marking it `[Required]` broke the very first 'New Cluster' form: the `DataAnnotationsValidator` fired before the populate step ran, blocking the submit with 'The PveName field is required.'.

### 3. `CopyToClipboardButton` — accept a `TextProvider` instead of a static `Text`

The button is now driven by `Func<string>` / `Func<Task<string>>` so callers can produce the value **lazily at click time** (e.g. building a JSON payload from form state). Existing call sites in `CopyValueDialog` and EE `AuditLogs` updated to `() => Value` lambdas.

## Test plan

- [ ] Page with many `<PermissionView>` (e.g. AdminArea overview) loads quickly under an admin user with all built-in roles
- [ ] First-time 'New Cluster' submit succeeds without 'PveName is required'
- [ ] `CopyValueDialog` still copies the value
- [ ] EE `AuditLogs` still copies `audit.Details`