### PR TITLE
Maintenance: per-schema operations + Compact + UI refactor

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/PostgreSqlHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/PostgreSqlHelper.cs
@@ -35,8 +35,16 @@ public static partial class PostgreSqlHelper
 
     /// <summary>
     /// Returns a double-quoted, safe PostgreSQL identifier ready for inclusion in raw SQL
-    /// (e.g. <c>"mydb"</c>). The inner value is validated with <see cref="SafeIdentifier"/>.
+    /// (e.g. <c>"my-db"</c>). Quoted identifiers may contain any character (hyphens, spaces,
+    /// reserved keywords) — the only escape needed inside a double-quoted identifier is the
+    /// double quote itself, which is escaped by doubling it.
     /// </summary>
     public static string QuoteIdentifier(string? identifier)
-        => $"\"{SafeIdentifier(identifier)}\"";
+    {
+        if (string.IsNullOrEmpty(identifier) || identifier.Length > MaxIdentifierLength)
+        {
+            throw new InvalidOperationException($"Invalid PostgreSQL identifier: '{identifier}'");
+        }
+        return $"\"{identifier.Replace("\"", "\"\"")}\"";
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Modularity/IModuleMaintenance.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Modularity/IModuleMaintenance.cs
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using Corsinvest.ProxmoxVE.Admin.Core.Persistence;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Modularity;
+
+public interface IModuleMaintenance
+{
+    Task ExecuteDatabaseMaintenanceAsync(DatabaseMaintenanceOperation operation, CancellationToken cancellationToken = default);
+    Task<long> GetDatabaseSize(CancellationToken cancellationToken = default);
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Modularity/ModuleBase.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Modularity/ModuleBase.cs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-using Corsinvest.ProxmoxVE.Admin.Core.Persistence;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth.Permissions;
 using Microsoft.AspNetCore.Builder;
@@ -69,7 +68,13 @@ public abstract class ModuleBase
     protected internal virtual Task RunAsync(IServiceScope scope) => Task.CompletedTask;
     protected internal virtual Task InitializeAsync(IServiceScope scope) => Task.CompletedTask;
     public virtual Task FixAsync(IServiceScope scope) => Task.CompletedTask;
-    public virtual Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation) => Task.CompletedTask;
+    /// <summary>
+    /// Hook for modules with persistence: return an <see cref="IModuleMaintenance"/>
+    /// (typically <c>new PostgreSqlModuleMaintenance&lt;ModuleDbContext&gt;(scope)</c>)
+    /// so the system maintenance UI can run vacuum / reindex / size queries per-schema.
+    /// Returns null for modules without persistence; the maintenance UI skips them.
+    /// </summary>
+    public virtual IModuleMaintenance? GetMaintenance(IServiceScope scope) => null;
 
     public async Task RefreshSettingsEventAsync(IServiceScope scope)
     {

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/DatabaseMaintenanceOperation.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/DatabaseMaintenanceOperation.cs
@@ -10,12 +10,22 @@ namespace Corsinvest.ProxmoxVE.Admin.Core.Persistence;
 public enum DatabaseMaintenanceOperation
 {
     /// <summary>
-    /// Optimize database - reclaims storage and improves performance
+    /// Optimize (VACUUM ANALYZE) — refresh statistics and mark dead rows reusable.
+    /// Concurrent read/write friendly; does not lock the table and does not shrink the file on disk.
     /// </summary>
     Optimize,
 
     /// <summary>
-    /// Reindex database - rebuilds all indexes
+    /// Reindex (REINDEX SCHEMA) — rebuild every index in the module's schema.
+    /// Holds a short lock per index; safe for routine maintenance.
     /// </summary>
-    Reindex
+    Reindex,
+
+    /// <summary>
+    /// Compact (VACUUM FULL) — rewrite each table from scratch and return reclaimed space to the
+    /// filesystem. Holds an ACCESS EXCLUSIVE lock for the whole operation: tables cannot be read
+    /// or written while it runs. Requires temporary disk space roughly equal to the biggest table.
+    /// Use after massive cleanups (audit logs, tasks, old scans) — not as routine maintenance.
+    /// </summary>
+    Compact
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/ModuleDbContextBase.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/ModuleDbContextBase.cs
@@ -38,12 +38,4 @@ public abstract class ModuleDbContextBase<T>(DbContextOptions<T> options) : DbCo
     /// <param name="modelBuilder">The model builder</param>
     protected abstract void ConfigureEntities(ModelBuilder modelBuilder);
 
-    public Task ExecuteMaintenanceAsync(DatabaseMaintenanceOperation operation, CancellationToken cancellationToken = default)
-        => Database.ExecuteSqlRawAsync(operation switch
-        {
-            // PostgreSQL specific commands (can be extended for other databases)
-            DatabaseMaintenanceOperation.Optimize => "VACUUM ANALYZE",
-            DatabaseMaintenanceOperation.Reindex => $"REINDEX DATABASE {PostgreSqlHelper.QuoteIdentifier(Database.GetDbConnection().Database)}",
-            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unknown maintenance operation")
-        }, cancellationToken);
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/PostgreSqlModuleMaintenance.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/PostgreSqlModuleMaintenance.cs
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using Microsoft.EntityFrameworkCore;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Persistence;
+
+/// <summary>
+/// PostgreSQL-specific implementation of <see cref="IModuleMaintenance"/>.
+/// Operates against a single schema (auto-detected from the DbContext's default schema)
+/// — never the whole database — so each module's maintenance is independent.
+/// </summary>
+public class PostgreSqlModuleMaintenance(DbContext context) : IModuleMaintenance
+{
+    private readonly string _schema = context.Model.GetDefaultSchema()
+                  ?? throw new InvalidOperationException(
+                      $"DbContext '{context.GetType().Name}' has no default schema set. Add modelBuilder.HasDefaultSchema(\"...\") in OnModelCreating.");
+
+    /// <inheritdoc />
+    public async Task ExecuteDatabaseMaintenanceAsync(DatabaseMaintenanceOperation operation, CancellationToken cancellationToken = default)
+    {
+        // PostgreSQL does not allow parametrising identifiers; the schema and table names are
+        // already passed through PostgreSqlHelper.QuoteIdentifier, so EF1002 is a false positive.
+        var schema = PostgreSqlHelper.QuoteIdentifier(_schema);
+
+        switch (operation)
+        {
+            case DatabaseMaintenanceOperation.Reindex:
+#pragma warning disable EF1002
+                await context.Database.ExecuteSqlRawAsync($"REINDEX SCHEMA {schema}", cancellationToken);
+#pragma warning restore EF1002
+                return;
+
+            case DatabaseMaintenanceOperation.Optimize:
+            case DatabaseMaintenanceOperation.Compact:
+                var verb = operation == DatabaseMaintenanceOperation.Compact ? "VACUUM (FULL, ANALYZE)" : "VACUUM (ANALYZE)";
+                foreach (var table in await GetSchemaTableNamesAsync(cancellationToken))
+                {
+#pragma warning disable EF1002
+                    await context.Database.ExecuteSqlRawAsync($"{verb} {schema}.{PostgreSqlHelper.QuoteIdentifier(table)}", cancellationToken);
+#pragma warning restore EF1002
+                }
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unknown maintenance operation");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<long> GetDatabaseSize(CancellationToken cancellationToken = default)
+    {
+        var conn = context.Database.GetDbConnection();
+        if (conn.State != global::System.Data.ConnectionState.Open) { await conn.OpenAsync(cancellationToken); }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COALESCE(SUM(pg_total_relation_size(format('%I.%I', schemaname, tablename))), 0)::bigint
+            FROM pg_tables WHERE schemaname = @schema
+            """;
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@schema";
+        p.Value = _schema;
+        cmd.Parameters.Add(p);
+
+        var result = await cmd.ExecuteScalarAsync(cancellationToken);
+        return result is long l ? l : 0L;
+    }
+
+    private async Task<IReadOnlyList<string>> GetSchemaTableNamesAsync(CancellationToken cancellationToken)
+    {
+        var conn = context.Database.GetDbConnection();
+        if (conn.State != global::System.Data.ConnectionState.Open) { await conn.OpenAsync(cancellationToken); }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT tablename FROM pg_tables WHERE schemaname = @schema ORDER BY tablename";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@schema";
+        p.Value = _schema;
+        cmd.Parameters.Add(p);
+
+        var tables = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            tables.Add(reader.GetString(0));
+        }
+        return tables;
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/PostgreSqlModuleMaintenance`1.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Persistence/PostgreSqlModuleMaintenance`1.cs
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace Corsinvest.ProxmoxVE.Admin.Core.Persistence;
+
+/// <summary>
+/// Convenience generic over <see cref="PostgreSqlModuleMaintenance"/> for modules whose
+/// DbContext inherits <see cref="ModuleDbContextBase{T}"/>. Resolves the DbContext from
+/// the provided scope so the module only writes:
+/// <code>
+/// public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+///     =&gt; new PostgreSqlModuleMaintenance&lt;ModuleDbContext&gt;(scope);
+/// </code>
+/// </summary>
+public class PostgreSqlModuleMaintenance<T> : PostgreSqlModuleMaintenance
+    where T : ModuleDbContextBase<T>
+{
+    public PostgreSqlModuleMaintenance(IServiceScope scope)
+        : base(scope.GetRequiredService<T>()) { }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Module.cs
@@ -110,8 +110,8 @@ public class Module : ModuleBase
         => AddSettings<Settings, Components.RenderSettings>(services)
             .AddDbContextFactoryPostgreSql<ModuleDbContext>("autosnap");
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Module.cs
@@ -113,8 +113,8 @@ public class Module : ModuleBase
         InitializeJob(scope);
     }
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Module.cs
@@ -53,8 +53,8 @@ public class Module : ModuleBase
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         => services.AddDbContextFactoryPostgreSql<ModuleDbContext>("dashboard");
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Module.cs
@@ -86,8 +86,8 @@ public class Module : ModuleBase
         InitializeJob(scope);
     }
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Module.cs
@@ -75,8 +75,8 @@ public class Module : ModuleBase
         InitializeJob(scope);
     }
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Module.cs
@@ -98,8 +98,8 @@ public class Module : ModuleBase
         InitializeJob(scope);
     }
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Maintenance.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Maintenance.razor
@@ -12,7 +12,8 @@
                       ButtonStyle="ButtonStyle.Danger"
                       Size="ButtonSize.Large"
                       Click="FixAllAsync"
-                      IsBusy="IsFixAllBusy" />
+                      IsBusy="IsFixAllBusy"
+                      Disabled="@(IsAnyBusy && !IsFixAllBusy)" />
     </RadzenCard>
 
     <RadzenFieldset Text="@L["Database Maintenance"]" class="rz-panel">
@@ -22,7 +23,8 @@
                               Text="@L["Cleanup Audit Logs"]"
                               ButtonStyle="ButtonStyle.Danger"
                               Click="CleanupAuditLogsAsync"
-                              IsBusy="IsCleanupAuditLogsBusy" />
+                              IsBusy="IsCleanupAuditLogsBusy"
+                              Disabled="@(IsAnyBusy && !IsCleanupAuditLogsBusy)" />
                 <RadzenFormField Text="@L["Keep last days"]" AllowFloatingLabel="false">
                     <RadzenNumeric @bind-Value="AuditLogRetentionDays" Min="1" Max="3650" Style="width:90px;" />
                 </RadzenFormField>
@@ -33,7 +35,8 @@
                               Text="@L["Cleanup System Logs"]"
                               ButtonStyle="ButtonStyle.Danger"
                               Click="CleanupSystemLogsAsync"
-                              IsBusy="IsCleanupSystemLogsBusy" />
+                              IsBusy="IsCleanupSystemLogsBusy"
+                              Disabled="@(IsAnyBusy && !IsCleanupSystemLogsBusy)" />
                 <RadzenFormField Text="@L["Keep last days"]" AllowFloatingLabel="false">
                     <RadzenNumeric @bind-Value="SystemLogsRetentionDays" Min="1" Max="3650" Style="width:90px;" />
                 </RadzenFormField>
@@ -44,7 +47,8 @@
                               Text="@L["Cleanup Task History"]"
                               ButtonStyle="ButtonStyle.Danger"
                               Click="CleanupTaskHistoryAsync"
-                              IsBusy="IsCleanupTaskHistoryBusy" />
+                              IsBusy="IsCleanupTaskHistoryBusy"
+                              Disabled="@(IsAnyBusy && !IsCleanupTaskHistoryBusy)" />
                 <RadzenFormField Text="@L["Keep last days"]" AllowFloatingLabel="false">
                     <RadzenNumeric @bind-Value="TaskHistoryRetentionDays" Min="1" Max="3650" Style="width:90px;" />
                 </RadzenFormField>
@@ -57,12 +61,21 @@
                               Text="@L["Reindex"]"
                               ButtonStyle="ButtonStyle.Primary"
                               Click="DbReindexAsync"
-                              IsBusy="IsDbReindexBusy" />
+                              IsBusy="IsDbReindexBusy"
+                              Disabled="@(IsAnyBusy && !IsDbReindexBusy)" />
                 <RadzenButton Icon="storage"
                               Text="@L["Optimize"]"
                               ButtonStyle="ButtonStyle.Primary"
                               Click="DbOptimizeAsync"
-                              IsBusy="IsOptimizeDDatabaseBusy" />
+                              IsBusy="IsOptimizeDDatabaseBusy"
+                              Disabled="@(IsAnyBusy && !IsOptimizeDDatabaseBusy)" />
+                <RadzenButton Icon="compress"
+                              Text="@L["Compact (full)"]"
+                              ButtonStyle="ButtonStyle.Danger"
+                              Click="DbCompactAsync"
+                              IsBusy="IsDbCompactBusy"
+                              Disabled="@(IsAnyBusy && !IsDbCompactBusy)"
+                              title="@L["Reclaims disk space. Locks tables — use only after large cleanups."]" />
             </RadzenStack>
         </RadzenStack>
     </RadzenFieldset>
@@ -75,7 +88,8 @@
                                   Text="@L["Clear Memory Cache"]"
                                   ButtonStyle="ButtonStyle.Warning"
                                   Click="ClearMemoryCacheAsync"
-                                  IsBusy="IsClearMemoryCacheBusy" />
+                                  IsBusy="IsClearMemoryCacheBusy"
+                                  Disabled="@(IsAnyBusy && !IsClearMemoryCacheBusy)" />
                 </RadzenStack>
             </RadzenFieldset>
         </RadzenColumn>
@@ -87,7 +101,8 @@
                                   Text="@L["Cleanup Failed Jobs"]"
                                   ButtonStyle="ButtonStyle.Warning"
                                   Click="CleanupFailedJobsAsync"
-                                  IsBusy="IsCleanupFailedJobsBusy" />
+                                  IsBusy="IsCleanupFailedJobsBusy"
+                                  Disabled="@(IsAnyBusy && !IsCleanupFailedJobsBusy)" />
                 </RadzenStack>
             </RadzenFieldset>
         </RadzenColumn>
@@ -99,13 +114,15 @@
                                   Text="@L["Test Cluster Connections"]"
                                   ButtonStyle="ButtonStyle.Success"
                                   Click="TestClusterConnectionsAsync"
-                                  IsBusy="IsTestClusterConnectionsBusy" />
+                                  IsBusy="IsTestClusterConnectionsBusy"
+                                  Disabled="@(IsAnyBusy && !IsTestClusterConnectionsBusy)" />
 
                     <RadzenButton Icon="public"
                                   Text="@L["Test Internet Connectivity"]"
                                   ButtonStyle="ButtonStyle.Info"
                                   Click="TestInternetConnectivityAsync"
-                                  IsBusy="IsTestInternetConnectivityBusy" />
+                                  IsBusy="IsTestInternetConnectivityBusy"
+                                  Disabled="@(IsAnyBusy && !IsTestInternetConnectivityBusy)" />
                 </RadzenStack>
             </RadzenFieldset>
         </RadzenColumn>
@@ -113,22 +130,46 @@
 
     <RadzenFieldset class="rz-panel">
         <HeaderTemplate>
-            <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween" Style="width:100%">
+            <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
                 <span>@L["Log"]</span>
-                <RadzenButton Icon="delete_sweep"
-                              Text="@L["Clear"]"
-                              ButtonStyle="ButtonStyle.Light"
-                              Size="ButtonSize.Small"
-                              Click="ClearLog"
-                              Disabled="@(!LogMessages.Any())" />
+                @if (LogMessages.Any())
+                {
+                    <RadzenBadge BadgeStyle="BadgeStyle.Light" Text="@LogMessages.Count.ToString()" />
+                }
             </RadzenStack>
         </HeaderTemplate>
         <ChildContent>
-            <RadzenStack Gap="0.15rem" Style="max-height: 300px; overflow-y: auto; font-family: monospace; font-size: 0.82rem;">
-                @foreach (var msg in LogMessages)
+            <RadzenStack Gap="0.5rem">
+                <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+                    <CopyToClipboardButton TextProvider="@(() => string.Join(Environment.NewLine, LogMessages))" />
+                    <RadzenButton Icon="delete_sweep"
+                                  Text="@L["Clear"]"
+                                  ButtonStyle="ButtonStyle.Danger"
+                                  Size="ButtonSize.Small"
+                                  Click="ClearLog"
+                                  Disabled="@(!LogMessages.Any())" />
+                </RadzenStack>
+
+                @if (IsAnyBusy)
                 {
-                    <span style="@GetLogStyle(msg)">@msg</span>
+                    <RadzenProgressBar Mode="ProgressBarMode.Indeterminate"
+                                       Style="height: 4px;"
+                                       ShowValue="false" />
                 }
+
+                <RadzenStack Gap="0.15rem" Style="max-height: 300px; overflow-y: auto; font-family: monospace; font-size: 0.82rem; background: var(--rz-base-200); padding: 0.5rem; border-radius: var(--rz-border-radius);">
+                    @if (LogMessages.Any())
+                    {
+                        @foreach (var msg in LogMessages)
+                        {
+                            <span style="@GetLogStyle(msg)">@msg</span>
+                        }
+                    }
+                    else
+                    {
+                        <span class="rz-text-tertiary-color" style="font-style: italic;">@L["No log entries yet."]</span>
+                    }
+                </RadzenStack>
             </RadzenStack>
         </ChildContent>
     </RadzenFieldset>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Maintenance.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Components/Maintenance.razor.cs
@@ -25,12 +25,30 @@ public partial class Maintenance(IAdminService adminService,
     private bool IsCleanupAuditLogsBusy { get; set; }
     private bool IsDbReindexBusy { get; set; }
     private bool IsOptimizeDDatabaseBusy { get; set; }
+    private bool IsDbCompactBusy { get; set; }
     private bool IsClearMemoryCacheBusy { get; set; }
     private bool IsCleanupFailedJobsBusy { get; set; }
     private bool IsTestClusterConnectionsBusy { get; set; }
     private bool IsTestInternetConnectivityBusy { get; set; }
     private bool IsCleanupSystemLogsBusy { get; set; }
     private bool IsCleanupTaskHistoryBusy { get; set; }
+
+    /// <summary>
+    /// True while ANY maintenance operation is running. Used by the UI to disable
+    /// the other action buttons (so the user can't queue Optimize while Reindex
+    /// is still running) and to show a progress bar above the log.
+    /// </summary>
+    private bool IsAnyBusy => IsFixAllBusy
+                              || IsCleanupAuditLogsBusy
+                              || IsDbReindexBusy
+                              || IsOptimizeDDatabaseBusy
+                              || IsDbCompactBusy
+                              || IsClearMemoryCacheBusy
+                              || IsCleanupFailedJobsBusy
+                              || IsTestClusterConnectionsBusy
+                              || IsTestInternetConnectivityBusy
+                              || IsCleanupSystemLogsBusy
+                              || IsCleanupTaskHistoryBusy;
 
     private List<string> LogMessages { get; set; } = [];
     private int AuditLogRetentionDays { get; set; } = 180; // Default 6 months
@@ -202,19 +220,27 @@ public partial class Maintenance(IAdminService adminService,
             try
             {
                 AddLog("Starting database reindex...");
+                long reindexTotalBefore = 0;
+                long reindexTotalAfter = 0;
                 foreach (var item in moduleService.Modules)
                 {
+                    var maintenance = item.GetMaintenance(scope);
+                    if (maintenance == null) { continue; }
                     try
                     {
-                        await item.DatabaseMaintenanceAsync(scope, DatabaseMaintenanceOperation.Reindex);
-                        AddLog($"OK Reindex {item.Name}");
+                        var before = await maintenance.GetDatabaseSize();
+                        await maintenance.ExecuteDatabaseMaintenanceAsync(DatabaseMaintenanceOperation.Reindex);
+                        var after = await maintenance.GetDatabaseSize();
+                        reindexTotalBefore += before;
+                        reindexTotalAfter += after;
+                        AddLog($"OK Reindex {item.Name}: {FormatBytes(before)} -> {FormatBytes(after)}");
                     }
                     catch (Exception ex)
                     {
                         AddLog($"FAIL Reindex {item.Name}: {ex.Message}");
                     }
                 }
-                AddLog("Database reindex completed");
+                AddLog($"Database reindex completed: total {FormatBytes(reindexTotalBefore)} -> {FormatBytes(reindexTotalAfter)}");
                 await auditService.LogAsync("Maintenance.DbReindex", true, "Completed");
             }
             catch (Exception ex)
@@ -238,19 +264,27 @@ public partial class Maintenance(IAdminService adminService,
             try
             {
                 AddLog("Starting database optimize...");
+                long optimizeTotalBefore = 0;
+                long optimizeTotalAfter = 0;
                 foreach (var item in moduleService.Modules)
                 {
+                    var maintenance = item.GetMaintenance(scope);
+                    if (maintenance == null) { continue; }
                     try
                     {
-                        await item.DatabaseMaintenanceAsync(scope, DatabaseMaintenanceOperation.Optimize);
-                        AddLog($"OK Optimize {item.Name}");
+                        var before = await maintenance.GetDatabaseSize();
+                        await maintenance.ExecuteDatabaseMaintenanceAsync(DatabaseMaintenanceOperation.Optimize);
+                        var after = await maintenance.GetDatabaseSize();
+                        optimizeTotalBefore += before;
+                        optimizeTotalAfter += after;
+                        AddLog($"OK Optimize {item.Name}: {FormatBytes(before)} -> {FormatBytes(after)}");
                     }
                     catch (Exception ex)
                     {
                         AddLog($"FAIL Optimize {item.Name}: {ex.Message}");
                     }
                 }
-                AddLog("Database optimize completed");
+                AddLog($"Database optimize completed: total {FormatBytes(optimizeTotalBefore)} -> {FormatBytes(optimizeTotalAfter)}");
                 await auditService.LogAsync("Maintenance.DbOptimize", true, "Completed");
             }
             catch (Exception ex)
@@ -263,6 +297,77 @@ public partial class Maintenance(IAdminService adminService,
                 IsOptimizeDDatabaseBusy = false;
             }
         }
+    }
+
+    private async Task DbCompactAsync()
+    {
+        // Explicit, verbose confirmation: Compact (VACUUM FULL) holds an ACCESS EXCLUSIVE
+        // lock per table and needs disk space ~= biggest table. Never run as routine maintenance.
+        if (!await dialogService.ConfirmAsync(
+                L["Compact rewrites each table from scratch to reclaim disk space. The application becomes unresponsive while it runs (typically minutes) and requires temporary free disk space roughly equal to your largest table. Run this only after large cleanups (audit logs, task history, old reports). Are you sure?"],
+                L["Confirm Database Compact (VACUUM FULL)"],
+                true))
+        {
+            return;
+        }
+
+        using var scope = serviceScopeFactory.CreateScope();
+        IsDbCompactBusy = true;
+        try
+        {
+            AddLog("Starting database compact (VACUUM FULL)...");
+
+            long totalBefore = 0;
+            long totalAfter = 0;
+
+            foreach (var item in moduleService.Modules)
+            {
+                var maintenance = item.GetMaintenance(scope);
+                if (maintenance == null) { continue; }
+                try
+                {
+                    var before = await maintenance.GetDatabaseSize();
+                    await maintenance.ExecuteDatabaseMaintenanceAsync(DatabaseMaintenanceOperation.Compact);
+                    var after = await maintenance.GetDatabaseSize();
+
+                    totalBefore += before;
+                    totalAfter += after;
+
+                    AddLog($"OK Compact {item.Name}: {FormatBytes(before)} -> {FormatBytes(after)} (reclaimed {FormatBytes(before - after)})");
+                }
+                catch (Exception ex)
+                {
+                    AddLog($"FAIL Compact {item.Name}: {ex.Message}");
+                }
+            }
+
+            AddLog($"Database compact completed: total {FormatBytes(totalBefore)} -> {FormatBytes(totalAfter)} (reclaimed {FormatBytes(totalBefore - totalAfter)})");
+            await auditService.LogAsync("Maintenance.DbCompact",
+                                        true,
+                                        $"Before {totalBefore} bytes, after {totalAfter} bytes, reclaimed {totalBefore - totalAfter} bytes");
+        }
+        catch (Exception ex)
+        {
+            AddLog($"FAIL Database Compact: {ex.Message}");
+            await auditService.LogAsync("Maintenance.DbCompact", false, ex.Message);
+        }
+        finally
+        {
+            IsDbCompactBusy = false;
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double size = Math.Abs(bytes);
+        int unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+        return $"{(bytes < 0 ? "-" : "")}{size:0.##} {units[unit]}";
     }
 
     // Cache Management

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Module.cs
@@ -207,8 +207,10 @@ public class Module : ModuleBase
                    .AddReleaseServices()
                    .AddTaskTracker();
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    // Non-generic PostgreSqlModuleMaintenance because the System ModuleDbContext inherits
+    // from IdentityDbContext, not ModuleDbContextBase<T>.
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance(scope.GetRequiredService<ModuleDbContext>());
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Persistence/ModuleDbContext.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Persistence/ModuleDbContext.cs
@@ -2,7 +2,6 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-using Corsinvest.ProxmoxVE.Admin.Core.Persistence;
 using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth;
 using Corsinvest.ProxmoxVE.Admin.Core.TaskTracking;
 using Corsinvest.ProxmoxVE.Admin.Module.System.Settings.Models;
@@ -172,12 +171,4 @@ public class ModuleDbContext(DbContextOptions<ModuleDbContext> options)
         });
     }
 
-    public Task ExecuteMaintenanceAsync(DatabaseMaintenanceOperation operation, CancellationToken cancellationToken = default)
-        => Database.ExecuteSqlRawAsync(operation switch
-        {
-            // PostgreSQL specific commands (can be extended for other databases)
-            DatabaseMaintenanceOperation.Optimize => "VACUUM ANALYZE",
-            DatabaseMaintenanceOperation.Reindex => $"REINDEX DATABASE {PostgreSqlHelper.QuoteIdentifier(Database.GetDbConnection().Database)}",
-            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unknown maintenance operation")
-        }, cancellationToken);
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Module.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Module.cs
@@ -50,8 +50,8 @@ public class Module : ModuleBase
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
        => services.AddDbContextFactoryPostgreSql<ModuleDbContext>("system_reports");
 
-    public override Task DatabaseMaintenanceAsync(IServiceScope scope, DatabaseMaintenanceOperation operation)
-        => scope.GetRequiredService<ModuleDbContext>().ExecuteMaintenanceAsync(operation);
+    public override IModuleMaintenance GetMaintenance(IServiceScope scope)
+        => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
 
     public override Task FixAsync(IServiceScope scope) => RunAsync(scope);
 


### PR DESCRIPTION
## Summary

Refactor of the System Maintenance feature to operate **per-schema** instead of repeating database-wide operations once per installed module. Adds a new **Compact** (VACUUM FULL) operation and cleans up the maintenance UI.

### Why
The previous implementation called `DatabaseMaintenanceAsync` on every module, but each module ran `REINDEX DATABASE` / `VACUUM ANALYZE` on the **entire database**, so on an installation with N modules each click triggered N duplicate full-DB operations. It also failed outright on databases whose name contained a hyphen (e.g. `cv4pve-admin`) because of an identifier-quoting bug.

### What changed
**Architecture**
- New `IModuleMaintenance` contract returned by `ModuleBase.GetMaintenance(scope)`. Modules without persistence return `null` and are skipped by the maintenance UI.
- `PostgreSqlModuleMaintenance` + generic `PostgreSqlModuleMaintenance<T>` (where `T : ModuleDbContextBase<T>`) implement the contract for the standard EF-based modules. The non-generic variant is used by the `System` module whose context inherits from `IdentityDbContext`.
- Schema name is auto-detected via `DbContext.Model.GetDefaultSchema()` — single source of truth, no duplication with the `HasDefaultSchema(...)` call in `OnModelCreating`.
- Each `Module.cs` with persistence now has a single override:
  ```csharp
  public override IModuleMaintenance GetMaintenance(IServiceScope scope)
      => new PostgreSqlModuleMaintenance<ModuleDbContext>(scope);
  ```
  Replaces the two-method boilerplate that was previously duplicated in 10 modules.

**Operations**
- **Reindex** → `REINDEX SCHEMA "<module>"` (single statement, schema-scoped).
- **Optimize** → `VACUUM (ANALYZE) <module>.<table>` iterated over the schema tables.
- **Compact** (new) → `VACUUM (FULL, ANALYZE) <module>.<table>`, opt-in, with a verbose confirmation dialog about ACCESS EXCLUSIVE locks and disk-space requirements. Excluded from Fix All. Logs before/after size per module and reclaimed totals.

**UI**
- Log fieldset has a small toolbar with `Copy` (uses the existing `CopyToClipboardButton`) and `Clear` (Danger style).
- `IsAnyBusy` derived property: while any operation runs, the other action buttons are disabled (the running one keeps showing its spinner), and an indeterminate `RadzenProgressBar` appears above the log area.
- Empty-state placeholder when the log has no entries.

**Fixes**
- `PostgreSqlHelper.QuoteIdentifier` now accepts identifiers containing hyphens / reserved characters when properly quoted (fixes `Invalid PostgreSQL identifier: 'cv4pve-admin'` on Reindex).

## Test plan
- [ ] Build the solution
- [ ] Run the app and open System → Maintenance
- [ ] Click **Reindex** — confirm a single `REINDEX SCHEMA` per module is executed; verify the log shows one OK line per module with before/after size
- [ ] Click **Optimize** — confirm per-table VACUUM ANALYZE within the module schema; before/after sizes logged
- [ ] Click **Compact** — confirm dialog appears with the locking warning; verify reclaimed space is shown per module and as a total; verify it is NOT executed by **Fix All**
- [ ] Test on a database whose name contains a hyphen (`cv4pve-admin`) — Reindex must succeed
- [ ] Try clicking another action while one is running — should be disabled; progress bar visible above the log
- [ ] Verify modules without persistence (e.g. AI Server, Bots) are skipped silently
- [ ] Verify Copy/Clear in the log toolbar work

## Notes
- Translation keys for new strings (`Compact (full)`, dialog text, `Clear log`, etc.) are NOT included in this PR — they will be added in a separate documentation/translation PR. The English fallback strings are present in the source code, so the UI is fully functional in English.