### PR TITLE
Docker compose: optional fixed project name + bump Apprise to v1.11.0

### DIFF
--- a/src/docker/docker-compose-ce.yaml
+++ b/src/docker/docker-compose-ce.yaml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Repository: https://gitlab.com/Corsinvest/cv4pve-admin
 
+# Project name. If omitted, Docker Compose uses the name of the directory
+# containing this file (so by default this stack ends up named "docker",
+# producing containers like "docker-postgres-1"). Uncomment the line below to
+# pin a clear, fixed name independent of where you place the file — useful when
+# you run multiple compose stacks on the same host.
+# name: cv4pve-admin-ce
+
 services:
   # PostgreSQL Database
   postgres:

--- a/src/docker/docker-compose-ee.yaml
+++ b/src/docker/docker-compose-ee.yaml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Repository: https://gitlab.com/Corsinvest/cv4pve-admin
 
+# Project name. If omitted, Docker Compose uses the name of the directory
+# containing this file (so by default this stack ends up named "docker",
+# producing containers like "docker-postgres-1"). Uncomment the line below to
+# pin a clear, fixed name independent of where you place the file — useful when
+# you run multiple compose stacks on the same host.
+# name: cv4pve-admin-ee
+
 services:
   # PostgreSQL Database
   postgres:
@@ -27,7 +34,7 @@ services:
 
   # Apprise Notification Service
   apprise:
-    image: caronc/apprise:1.9.9
+    image: caronc/apprise:v1.11.0
     restart: unless-stopped
     environment:
       - APPRISE_WORKER_COUNT=1


### PR DESCRIPTION
## Summary

- Add a commented-out `name:` directive at the top of both `docker-compose-ce.yaml` and `docker-compose-ee.yaml`. By default Docker Compose derives the project name from the parent directory (`docker`), which produces container names like `docker-postgres-1` that collide visually when more than one compose stack runs on the same host. The note explains when it's worth uncommenting to pin a fixed name (`cv4pve-admin-ce` / `cv4pve-admin-ee`).
- EE compose: bump `caronc/apprise` from `1.9.9` to `v1.11.0`. Two upstream things users with existing channels should know:
  - Microsoft Teams connector retired by Microsoft and removed by Apprise upstream — switch to another channel.
  - `ntfy.sh` URLs that use `tags=` need to be changed to `xtags=` (Apprise v1.10 query param rename).

## Test plan
- [ ] `docker compose -f docker-compose-ce.yaml config` succeeds
- [ ] `docker compose -f docker-compose-ee.yaml config` succeeds
- [ ] `docker compose -f docker-compose-ee.yaml pull` retrieves `caronc/apprise:v1.11.0`
- [ ] Verify the stack still starts end-to-end (`./admin.ps1 run`)
- [ ] If you have an Apprise notifier configured, send a test notification