### PR TITLE
Diagnostic: CE Compliance placeholder + PDF wrap + clearable inputs

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Exporters/Excel/ExcelSheetBuilder.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Exporters/Excel/ExcelSheetBuilder.cs
@@ -69,10 +69,6 @@ public class ExcelSheetBuilder
     private static bool IsGravityColumn(string name)
         => name is "Gravity" or "Status";
 
-    /// <summary>
-    /// Pastel background + bold dark foreground on cells matching gravity/status keywords.
-    /// Same palette as the PDF report for visual consistency.
-    /// </summary>
     private static void ApplyGravityConditionalFormatting(IXLRangeColumn dataCol)
     {
         Apply("Critical", "#F8D7DA", "#721C24");
@@ -89,6 +85,12 @@ public class ExcelSheetBuilder
             cf.Font.SetFontColor(XLColor.FromHtml(fg));
             cf.Font.SetBold(true);
         }
+    }
+
+    public ExcelSheetBuilder AddEnterprisePlaceholder(string availableLabel, string ctaLabel)
+    {
+        _currentRow += SubscriptionGateReportHelper.AddEnterprisePlaceholder(_ws, _currentRow, availableLabel, ctaLabel);
+        return this;
     }
 
     internal void FinalizeSheet() => _ws.Columns().AdjustToContents(1, 80);

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/SubscriptionGateReportHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Helpers/SubscriptionGateReportHelper.cs
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using ClosedXML.Excel;
+using MigraDoc.DocumentObjectModel;
+using MigraDoc.DocumentObjectModel.Tables;
+using MigraDocColors = MigraDoc.DocumentObjectModel.Colors;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Helpers;
+
+public static class SubscriptionGateReportHelper
+{
+    public static void AddEnterprisePlaceholder(Section section,
+                                                string availableLabel,
+                                                string ctaLabel)
+    {
+        // Centered yellow-bordered box that mimics SubscriptionGate.razor.
+        var table = section.AddTable();
+        table.Borders.Width = 1.5;
+        table.Borders.Color = MigraDocColors.Orange;
+        table.AddColumn(Unit.FromCentimeter(19));
+
+        var row = table.AddRow();
+        var cell = row.Cells[0];
+        cell.Shading.Color = new Color(255, 248, 220); // soft yellow background
+        cell.Format.Alignment = ParagraphAlignment.Center;
+        cell.VerticalAlignment = VerticalAlignment.Center;
+        cell.Format.SpaceBefore = Unit.FromMillimeter(4);
+        cell.Format.SpaceAfter = Unit.FromMillimeter(4);
+
+        var msg = cell.AddParagraph(availableLabel);
+        msg.Format.Font.Size = 12;
+        msg.Format.Font.Bold = true;
+        msg.Format.Alignment = ParagraphAlignment.Center;
+
+        var link = cell.AddParagraph();
+        link.Format.Alignment = ParagraphAlignment.Center;
+        link.Format.SpaceBefore = Unit.FromMillimeter(2);
+        var hyperlink = link.AddHyperlink(ApplicationHelper.ShopSubscriptionUrl, HyperlinkType.Url);
+        var text = hyperlink.AddFormattedText(ctaLabel, TextFormat.Underline);
+        text.Color = MigraDocColors.Blue;
+    }
+
+    public static int AddEnterprisePlaceholder(IXLWorksheet sheet,
+                                               int startRow,
+                                               string availableLabel,
+                                               string ctaLabel)
+    {
+        var titleCell = sheet.Cell(startRow, 1);
+        titleCell.Value = availableLabel;
+        titleCell.Style.Font.Bold = true;
+        titleCell.Style.Font.FontSize = 14;
+        titleCell.Style.Font.FontColor = XLColor.DarkOrange;
+        titleCell.Style.Fill.BackgroundColor = XLColor.FromArgb(255, 248, 220);
+        sheet.Range(startRow, 1, startRow, 6).Merge();
+
+        var linkCell = sheet.Cell(startRow + 1, 1);
+        linkCell.Value = ctaLabel;
+        linkCell.SetHyperlink(new XLHyperlink(ApplicationHelper.ShopSubscriptionUrl));
+        linkCell.Style.Font.Underline = XLFontUnderlineValues.Single;
+        linkCell.Style.Font.FontColor = XLColor.Blue;
+        sheet.Range(startRow + 1, 1, startRow + 1, 6).Merge();
+
+        return 2;
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/IssuesDialog.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/IssuesDialog.razor
@@ -55,7 +55,7 @@
 <RadzenFormField Text="@L["Sub Context"]" AllowFloatingLabel="false">
     <Start><RadzenIcon Icon="subdirectory_arrow_right" /></Start>
     <ChildContent>
-        <RadzenTextBox Name="@nameof(Model.SubContext)" @bind-Value="@Model.SubContext" />
+        <RadzenTextBox Name="@nameof(Model.SubContext)" @bind-Value="@Model.SubContext" type="search" />
     </ChildContent>
     <Helper>
         <RadzenDataAnnotationValidator Component="@nameof(Model.SubContext)" />
@@ -65,7 +65,7 @@
 <RadzenFormField Text="@L["Description"]" AllowFloatingLabel="false">
     <Start><RadzenIcon Icon="notes" /></Start>
     <ChildContent>
-        <RadzenTextBox Name="@nameof(Model.Description)" @bind-Value="@Model.Description" />
+        <RadzenTextBox Name="@nameof(Model.Description)" @bind-Value="@Model.Description" type="search" />
     </ChildContent>
     <Helper>
         <RadzenDataAnnotationValidator Component="@nameof(Model.Description)" />

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/DiagnosticService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Services/DiagnosticService.cs
@@ -99,11 +99,19 @@ public class DiagnosticService(IStringLocalizer<DiagnosticService> L, ISettingsS
         var section = CreateSection(document);
 
         AddTitle(section, result);
+        AddExecutiveSummary(section, result);
         AddIssuesSection(section, result);
+        AddComplianceSections(section, result);
         AddFooter(section);
 
         return Render(document);
     }
+
+    /// <summary>
+    /// Hook for the Executive Summary block printed right after the title.
+    /// CE base prints nothing; EE renders the gravity counters and the top critical issues.
+    /// </summary>
+    protected virtual void AddExecutiveSummary(Section section, JobResult result) { }
 
     protected virtual Stream GenerateExcel(JobResult result)
     {
@@ -111,9 +119,66 @@ public class DiagnosticService(IStringLocalizer<DiagnosticService> L, ISettingsS
 
         AddIssuesSheet(builder, result);
         AddIgnoredIssuesSheet(builder, result);
+        AddComplianceSheets(builder, result);
 
         return builder.Build(L["Diagnostic result of cluster '{0}' Date {1}", result.ClusterName, result.Start]);
     }
+
+    /// <summary>
+    /// CE base renders a single "Compliance" page that points the user to the Enterprise Edition.
+    /// EE overrides this and renders one full page per supported standard, reusing
+    /// <see cref="AddComplianceHeader"/> for the per-page boilerplate (page break + title + disclaimer).
+    /// </summary>
+    protected virtual void AddComplianceSections(Section section, JobResult result)
+    {
+        AddComplianceHeader(section, L["Compliance"]);
+        SubscriptionGateReportHelper.AddEnterprisePlaceholder(
+            section,
+            L["Compliance mapping (ISO 27001, ISO 27017, ISO 27018, NIS2, DORA, GDPR, PCI DSS, NIST CSF, NIST SP 800-53, CIS Controls, SOC 2, AgID, ENS, C5) is available in the Enterprise Edition."],
+            L["Get Enterprise"]);
+    }
+
+    /// <summary>
+    /// Inserts a page break, a section title and the compact compliance disclaimer.
+    /// Shared between CE (one Compliance page) and EE (one page per standard) so that
+    /// every page extracted in isolation still carries the audit-scope notice.
+    /// </summary>
+    protected void AddComplianceHeader(Section section, string title)
+    {
+        section.AddPageBreak();
+
+        var titleParagraph = section.AddParagraph(title);
+        titleParagraph.Format.Font.Size = 14;
+        titleParagraph.Format.Font.Bold = true;
+        titleParagraph.Format.SpaceAfter = Unit.FromMillimeter(2);
+
+        var disclaimer = section.AddParagraph(ComplianceDisclaimerText());
+        disclaimer.Format.Font.Size = 7;
+        disclaimer.Format.Font.Italic = true;
+        disclaimer.Format.Font.Color = MigraDocColors.DarkGray;
+        disclaimer.Format.SpaceAfter = Unit.FromMillimeter(3);
+    }
+
+    /// <summary>
+    /// The disclaimer text that appears above every compliance section in PDF and on
+    /// every compliance sheet in Excel. Kept here in CE base so both editions stay in sync.
+    /// </summary>
+    protected string ComplianceDisclaimerText()
+        => L["The compliance mapping is automated and technical only — it covers the subset of each standard that can be verified from the Proxmox VE state. Policies, training, supplier management, physical security and other organisational controls are out of scope. A passing check confirms only that the specific automated rule passed; full conformity usually requires manual evidence (policies, procedures, evidence of operation). This report does not constitute a formal audit or certification."];
+
+    /// <summary>
+    /// CE base adds a single placeholder sheet. EE overrides it and adds one sheet per standard.
+    /// </summary>
+    protected virtual void AddComplianceSheets(ExcelBuilder builder, JobResult result)
+        => builder.AddSheet(L["Compliance"],
+                            L["Compliance mapping is available in the Enterprise Edition"],
+                            sheet =>
+                            {
+                                sheet.AddNote(L["Disclaimer"], ComplianceDisclaimerText());
+                                sheet.AddEnterprisePlaceholder(
+                                    L["Compliance mapping (ISO 27001, ISO 27017, ISO 27018, NIS2, DORA, GDPR, PCI DSS, NIST CSF, NIST SP 800-53, CIS Controls, SOC 2, AgID, ENS, C5) is available in the Enterprise Edition."],
+                                    L["Get Enterprise"]);
+                            });
 
     protected void AddIssuesSheet(ExcelBuilder builder, JobResult result)
         => builder.AddSheet("Issues",
@@ -252,8 +317,12 @@ public class DiagnosticService(IStringLocalizer<DiagnosticService> L, ISettingsS
             var row = table.AddRow();
             AddBreakableText(row.Cells[0], item.IdResource);
             row.Cells[1].AddParagraph(item.Context.ToString());
-            row.Cells[2].AddParagraph(item.SubContext ?? string.Empty);
-            row.Cells[3].AddParagraph(item.Description ?? string.Empty);
+            // SubContext and Description can contain long unbroken tokens — typically .NET type
+            // names or stack traces surfaced from API errors — that overflow the cell and spill
+            // past the right margin of the page. Insert zero-width spaces after separators so
+            // MigraDoc has wrap points inside the word.
+            AddBreakableText(row.Cells[2], item.SubContext);
+            AddBreakableText(row.Cells[3], item.Description);
             var cell = row.Cells[4];
             cell.AddParagraph(item.Gravity.ToString());
             ApplyGravityShading(cell, item.Gravity);


### PR DESCRIPTION
## Summary

CE-side preparation for the EE Compliance reports refactor (one section per standard). CE base provides the report orchestration; EE overrides individual hooks to render real content.

### Reports infrastructure
- **`SubscriptionGateReportHelper`** (new, in Core) renders the "Available in Enterprise Edition" placeholder for offline reports. It mirrors the visual idea of the Blazor `SubscriptionGate` component for MigraDoc (PDF) and ClosedXML (Excel): yellow-bordered box, bold message, clickable shop link using the existing `ApplicationHelper.ShopSubscriptionUrl`.
- **`ExcelSheetBuilder.AddEnterprisePlaceholder`** is the fluent-builder entry point that forwards to the helper.

### Diagnostic report
- `DiagnosticService.GeneratePdf` / `GenerateExcel` now call new virtual hooks: `AddExecutiveSummary`, `AddComplianceSections`, `AddComplianceSheets`. Default CE implementations are a no-op (Executive Summary) and a single placeholder page / sheet (Compliance). EE overrides them in `DiagnosticService.Enterprise` to print the full per-standard content.
- New shared `AddComplianceHeader(section, title)` builds the page break + title + compact disclaimer, so every Compliance page (1 in CE, N in EE) renders the same boilerplate.
- PDF cells now run **SubContext** and **Description** through `AddBreakableText` (previously applied only to Id). Long .NET type names surfacing inside API errors (e.g. `System.Collections.Generic.IEnumerable<…>`) used to overflow the cell and spill past the right page margin; zero-width spaces inserted after `.` `/` `\` `@` `-` `_` `:` let MigraDoc wrap inside the word.

### Ignored Issues dialog
- The **Sub Context** and **Description** text boxes now render as `type=\"search\"`, so the browser shows its native clear (×) button while the field has content — easier to wipe a long entry without `Ctrl+A` + `Delete`.

## Test plan
- [ ] Run a Diagnostic scan in CE; export PDF — Compliance section now appears with the EE placeholder + link
- [ ] Run a Diagnostic scan in EE; export PDF — Compliance section still prints all standards in full (visual regression check)
- [ ] Force a check to fail with a long error message (e.g. an `ApiError` returning a .NET type name) — PDF row wraps the text inside the cell, no overflow off the page margin
- [ ] Open the Ignored Issues dialog while editing an existing entry — the × icon appears at the end of Sub Context / Description and clears the field on click
- [ ] CE Excel export contains a "Compliance" sheet with the placeholder
- [ ] EE Excel export still produces one sheet per standard