### PR TITLE
BuildInfo: testing expiration 2 months + cleanup of dead Login scaffolding

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/BuildInfo.cs
@@ -8,7 +8,7 @@ namespace Corsinvest.ProxmoxVE.Admin.Core;
 
 public static class BuildInfo
 {
-    public const int TestingExpirationMonths = 1;
+    public const int TestingExpirationMonths = 2;
     public static readonly string Version = string.Empty;
     public static readonly string PreRelease = string.Empty;
     public static readonly bool IsTesting;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/Login.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/Account/Login/Login.razor
@@ -56,15 +56,6 @@ else
                      PasswordText="@L["Password"]"
                      RememberMeText="@L["Remember me"]" />
 
-        @*     <div>
-        <p>
-            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">
-                article
-                about setting up this ASP.NET application to support logging in via external services
-            </a>.
-        </p>
-    </div> *@
-
         @if (ExternalLogins.Any())
         {
             <form action="/PerformExternalLogin" method="post">


### PR DESCRIPTION
## Summary

Two small chores:

- **`BuildInfo.TestingExpirationMonths`**: bumped from `1` to `2`. Pre-release builds (RC, beta) now expire 2 months after BuildDate, giving evaluators a longer window without forcing us to ship a new RC just to extend the testing period. The expiration check itself is unchanged.
- **`Login.razor`**: removed a commented-out block of original ASP.NET Identity scaffolding (the "There are no external authentication services configured" boilerplate). The page already renders the live `ExternalLogins` form right below — the dead comment was just visual noise.

## Test plan
- [ ] Build the solution
- [ ] Build a pre-release image (any `-rc`/`-beta` tag), boot it, verify the login page no longer shows the commented-out external-login Identity scaffolding
- [ ] Force-set the system clock to 2 months + 1 day past BuildDate — `IsTestingExpired` flips true and the expired-version banner appears on the login page