### PR TITLE
fix(docker): use caronc/apprise:latest tag

### DIFF
--- a/src/docker/docker-compose-ee.yaml
+++ b/src/docker/docker-compose-ee.yaml
@@ -34,7 +34,7 @@ services:
 
   # Apprise Notification Service
   apprise:
-    image: caronc/apprise:v1.11.0
+    image: caronc/apprise:latest
     restart: unless-stopped
     environment:
       - APPRISE_WORKER_COUNT=1


### PR DESCRIPTION
## Summary
- Switch Apprise EE compose image from `caronc/apprise:v1.11.0` to `caronc/apprise:latest`
- Upstream stopped publishing versioned tags after v1.5.0, so v1.11.0 was unreachable and `docker compose pull` failed

## Test plan
- [ ] `docker compose -f src/docker/docker-compose-ee.yaml pull apprise` succeeds
- [ ] Apprise container starts and `/details` returns the schema JSON catalog