### PR TITLE
docs: correct stale wwwroot/help references in build files

### DIFF
--- a/MkDocs.props
+++ b/MkDocs.props
@@ -1,7 +1,7 @@
 <Project>
   <!--
     Embeds the MkDocs documentation site (docs/user/) into the published app under
-    wwwroot/help/, so the running container can serve it offline on /help/.
+    a `help/` folder next to wwwroot, so the running container can serve it offline on /help/.
 
     This file does NOT build MkDocs — that's the caller's job, because the build
     environment differs across contexts:
@@ -24,7 +24,7 @@
   <Target Name="EnsureMkDocsBuilt" BeforeTargets="PrepareForPublish">
     <Error Condition="!Exists('$(MkDocsSiteDir)\index.html')"
            Text="MkDocs site not found at $(MkDocsSiteDir). Build it first: `./admin.ps1 -Command docs-build` (locally) or `mkdocs build` (CI). See ce/MkDocs.props for details." />
-    <Message Text="Embedding MkDocs site from $(MkDocsSiteDir) into wwwroot/help/" Importance="high" />
+    <Message Text="Embedding MkDocs site from $(MkDocsSiteDir) into the published app" Importance="high" />
   </Target>
 
   <!--

--- a/admin.ps1
+++ b/admin.ps1
@@ -207,7 +207,7 @@ switch ($Command) {
     "docs-build" {
         # Builds the static MkDocs site into docs/user/site/ using the same Docker
         # image that powers `docs-start`. Required before `dotnet publish`, which
-        # embeds site/ into wwwroot/help/ via MkDocs.props.
+        # embeds site/ into the published app via MkDocs.props.
         $docsPath = "$PSScriptRoot/docs/user"
         Write-Host "Building MkDocs static site into $docsPath/site/..." -ForegroundColor Cyan
         docker run --rm -v "${docsPath}:/docs" squidfunk/mkdocs-material:latest build --clean --strict

--- a/src/Corsinvest.ProxmoxVE.Admin/Corsinvest.ProxmoxVE.Admin.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin/Corsinvest.ProxmoxVE.Admin.csproj
@@ -6,7 +6,7 @@
   <!-- Docker configuration -->
   <Import Project="..\..\Docker.props" />
 
-  <!-- Embed MkDocs documentation into wwwroot/help/ on publish -->
+  <!-- Embed MkDocs documentation into the published app on publish -->
   <Import Project="..\..\MkDocs.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- The CI publish log printed `Embedding MkDocs site ... into wwwroot/help/`, but the `<ItemGroup>` in `MkDocs.props` actually copies the site to `help/` next to `wwwroot/` (intentionally, to bypass the .NET 10 `MapStaticAssets` compile-time manifest). Files are then served by a dedicated `UseStaticFiles` + `PhysicalFileProvider` middleware (`UseAdminCoreHelpDocs`).
- Updated the misleading message in `MkDocs.props` and the matching comments in `admin.ps1` (`docs-build` block) and `Corsinvest.ProxmoxVE.Admin.csproj`.
- Comment-only / message-only change, no build logic touched.

## Test plan
- [ ] `dotnet publish` still emits a message about embedding MkDocs
- [ ] Published output still contains `help/` next to `wwwroot/` and the running container serves docs on `/help/`