### PR TITLE
feat(adminctl): add self-update command

### DIFF
--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -23,6 +23,32 @@ Click it to trigger an immediate update via Watchtower (requires `WATCHTOWER_HTT
 
 The application checks for new versions every 12 hours.
 
+### Refresh `adminctl` and the compose files
+
+`adminctl` itself and the `docker-compose-{ce,ee}.yaml` files can fall behind over time.
+To pull the latest copy from GitHub `main`:
+
+```bash
+./adminctl self-update
+```
+
+This:
+
+- Downloads the latest `adminctl` + `docker-compose-{ce,ee}.yaml`
+- Snapshots the current files into `self-update-backups/<timestamp>/` so a rollback is always possible
+- Regenerates the active `docker-compose.yaml` to match the detected edition (CE or EE)
+- Leaves `.env`, `data/`, and `backups/` untouched
+
+If your `docker-compose.yaml` is customized (differs from both `docker-compose-ce.yaml` and `docker-compose-ee.yaml`), it is **not** rewritten — you will see a warning and can merge the changes manually by comparing with the updated `docker-compose-{ce,ee}.yaml`.
+
+After running, restart the stack to apply changes:
+
+```bash
+./adminctl restart
+# or, to pull new container images at the same time:
+docker compose up -d
+```
+
 ---
 
 ## Testing Pre-Release Versions

--- a/src/docker/adminctl
+++ b/src/docker/adminctl
@@ -17,9 +17,9 @@ fi
 
 show_help() {
     cat << 'EOF'
-  ______                _                      __
- / ____/___  __________(_)___ _   _____  _____/ /_
-/ /   / __ \/ ___/ ___/ / __ \ | / / _ \/ ___/ __/
+   ______                _                      __
+  / ____/___  __________(_)___ _   _____  _____/ /_
+ / /   / __ \/ ___/ ___/ / __ \ | / / _ \/ ___/ __/
 / /___/ /_/ / /  (__  ) / / / / |/ /  __(__  ) /_
 \____/\____/_/  /____/_/_/ /_/|___/\___/____/\__/
 
@@ -38,6 +38,7 @@ Commands:
       db create|list       Database backups
       data create|list     Application data backups
       all create|list      Full backups (db + data)
+  self-update              Update adminctl + compose files from GitHub
   help                     Show this help message
 
 Examples:
@@ -47,6 +48,7 @@ Examples:
   ./adminctl backup all list
   ./adminctl admin start
   ./adminctl admin stop
+  ./adminctl self-update
 
 Note: You can also use 'docker compose' commands directly if you prefer.
       See README.md for more information.
@@ -248,6 +250,94 @@ case "${1:-}" in
                 exit 1
                 ;;
         esac
+        ;;
+
+    self-update)
+        # Refresh adminctl + compose files from GitHub main. Does NOT touch
+        # .env, data/, or backups/.
+        BASE_URL="https://raw.githubusercontent.com/Corsinvest/cv4pve-admin/main/src/docker"
+        FILES=("adminctl" "docker-compose-ce.yaml" "docker-compose-ee.yaml")
+        TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+        SNAPSHOT_DIR="self-update-backups/${TIMESTAMP}"
+
+        echo "Self-updating adminctl and compose files from GitHub..."
+        echo "Source: ${BASE_URL}"
+        echo ""
+
+        # Detect active edition so we can regenerate docker-compose.yaml later.
+        ACTIVE_EDITION=""
+        if [ -f docker-compose.yaml ]; then
+            if [ -f docker-compose-ee.yaml ] && cmp -s docker-compose.yaml docker-compose-ee.yaml; then
+                ACTIVE_EDITION="ee"
+            elif [ -f docker-compose-ce.yaml ] && cmp -s docker-compose.yaml docker-compose-ce.yaml; then
+                ACTIVE_EDITION="ce"
+            else
+                echo "Warning: docker-compose.yaml looks customized — will not regenerate it."
+            fi
+        fi
+
+        # Download to staging first; partial failure leaves the install untouched.
+        STAGING_DIR=$(mktemp -d)
+        trap 'rm -rf "$STAGING_DIR"' EXIT
+
+        echo "Downloading latest files..."
+        for file in "${FILES[@]}"; do
+            echo "   - $file"
+            if ! curl -fsSL -o "${STAGING_DIR}/${file}" "${BASE_URL}/${file}"; then
+                echo "Failed to download ${file}. Aborting, no files changed."
+                exit 1
+            fi
+        done
+        echo ""
+
+        # Snapshot current files before overwriting.
+        mkdir -p "$SNAPSHOT_DIR"
+        echo "Snapshotting current files into ${SNAPSHOT_DIR}/"
+        for file in "${FILES[@]}" docker-compose.yaml; do
+            if [ -f "$file" ]; then
+                cp "$file" "${SNAPSHOT_DIR}/${file}"
+            fi
+        done
+        echo ""
+
+        echo "Changes detected:"
+        CHANGED=0
+        for file in "${FILES[@]}"; do
+            if [ ! -f "$file" ]; then
+                echo "   + $file (new)"
+                CHANGED=1
+            elif ! cmp -s "$file" "${STAGING_DIR}/${file}"; then
+                echo "   ~ $file (updated)"
+                CHANGED=1
+            fi
+        done
+        if [ $CHANGED -eq 0 ]; then
+            echo "   (none — already up to date)"
+            rm -rf "$SNAPSHOT_DIR"
+            rmdir self-update-backups 2>/dev/null || true
+            echo ""
+            echo "Already up to date."
+            exit 0
+        fi
+        echo ""
+
+        # Atomic mv: safe for the running script — kernel keeps the old inode alive until exit.
+        echo "Applying updates..."
+        for file in "${FILES[@]}"; do
+            mv "${STAGING_DIR}/${file}" "${file}"
+        done
+        chmod +x adminctl
+
+        if [ -n "$ACTIVE_EDITION" ]; then
+            cp "docker-compose-${ACTIVE_EDITION}.yaml" docker-compose.yaml
+            echo "   Regenerated docker-compose.yaml from docker-compose-${ACTIVE_EDITION}.yaml"
+        fi
+        echo ""
+
+        echo "Self-update complete."
+        echo "   Snapshot kept at: ${SNAPSHOT_DIR}/"
+        echo ""
+        echo "Next step: review changes, then './adminctl restart' (or 'docker compose up -d' to pull new images)."
         ;;
 
     help|--help|-h|"")


### PR DESCRIPTION
## Summary

Adds `./adminctl self-update` to refresh `adminctl` + `docker-compose-{ce,ee}.yaml` from GitHub `main`, with rollback-friendly snapshots.

## What it does

- Downloads the latest `adminctl`, `docker-compose-ce.yaml`, `docker-compose-ee.yaml` from `raw.githubusercontent.com/.../main/src/docker/` into a staging dir first — partial network failure leaves the installation untouched.
- Detects the active edition (CE or EE) by `cmp -s` against the matching `docker-compose-*.yaml` and regenerates `docker-compose.yaml` after the update so `docker compose` keeps pointing at the right edition.
- Snapshots the previous versions of every file it is about to overwrite into `self-update-backups/<YYYYMMDD_HHMMSS>/` for easy rollback.
- Atomic `mv` is used to overwrite the running `adminctl` itself — safe on Linux/macOS because the kernel keeps the in-use inode alive until the script exits.
- Prints a short diff summary (`+ new`, `~ updated`) before applying.
- Exits early with `Already up to date.` when nothing changed (no empty snapshot dir is created).
- **Does not touch** `.env`, `data/`, `backups/`.
- If `docker-compose.yaml` is customized (differs from both `compose-ce.yaml` and `compose-ee.yaml`), it is left untouched and a warning is emitted.

## Example output

\`\`\`
Self-updating adminctl and compose files from GitHub...
Source: https://raw.githubusercontent.com/Corsinvest/cv4pve-admin/main/src/docker

Downloading latest files...
   - adminctl
   - docker-compose-ce.yaml
   - docker-compose-ee.yaml

Snapshotting current files into self-update-backups/20260601_213045/

Changes detected:
   ~ adminctl (updated)
   ~ docker-compose-ee.yaml (updated)

Applying updates...
   Regenerated docker-compose.yaml from docker-compose-ee.yaml

Self-update complete.
   Snapshot kept at: self-update-backups/20260601_213045/

Next step: review changes, then './adminctl restart' (or 'docker compose up -d' to pull new images).
\`\`\`

## Test plan

- [ ] `./adminctl help` lists the new `self-update` command
- [ ] Running on an unmodified install pulls updates and creates a snapshot dir
- [ ] Running twice in a row prints `Already up to date.` the second time and does not create a second (empty) snapshot
- [ ] CE install regenerates `docker-compose.yaml` from `docker-compose-ce.yaml`; EE from `docker-compose-ee.yaml`
- [ ] A customized `docker-compose.yaml` (different from both editions) triggers the warning and is left untouched
- [ ] Killing the network mid-download (or pointing `BASE_URL` to an invalid host) aborts the run without modifying any local file