### PR TITLE
chore(deps): bump Aspire 13.4.0, pin Postgres 17, Corsinvest API Extension 9.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
   </ItemGroup>
   <!-- Proxmox VE -->
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.0" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.1" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.TelegramBot.Api" Version="1.9.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Metrics.Exporter.Api" Version="2.0.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.AutoSnap.Api" Version="2.1.1" />

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.0" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Program.cs
@@ -6,7 +6,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 //var mailpit = builder.AddMailPit("mailpit");
 
+// Pinned to 17: Postgres 18+ changed PGDATA layout (subdirectory per major
+// version) and refuses to start against volumes created by 17.x without an
+// explicit pg_upgrade. Bump only after a tested migration.
 var postgres = builder.AddPostgres("postgres", port: 5432)
+                      .WithImageTag("17")
                       .WithContainerName("postgres-cv4pve-admin")
                       .WithDataVolume()
                       //.WithPgAdmin()


### PR DESCRIPTION
## Summary
- Bump Aspire AppHost / PostgreSQL / MailPit packages **13.3.5 → 13.4.0**
- Bump `Corsinvest.ProxmoxVE.Api.Extension` **9.2.0 → 9.2.1**
- Pin Postgres container to image tag **17** in Aspire AppHost (Postgres 18+ changed the PGDATA layout and refuses to start against volumes created by 17.x without an explicit `pg_upgrade`)

## Test plan
- [x] Solution builds clean (0 errors)
- [ ] Aspire AppHost starts and Postgres 17 container comes up against existing data volume
- [ ] App boots, login works