### PR TITLE
refactor(core): introduce GridLoader for paginated data grids

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/GridLoader.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/GridLoader.cs
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
+
+public static class GridLoader
+{
+    public static GridLoader<TSource, TResult> Create<TSource, TResult>(
+        RadzenDataGrid<TResult> grid,
+        string? defaultOrderBy = null,
+        ILogger? logger = null)
+        where TSource : class
+        where TResult : notnull
+    {
+        ArgumentNullException.ThrowIfNull(grid);
+
+        defaultOrderBy ??= TryInferDefaultOrderBy(grid);
+        return new GridLoader<TSource, TResult>(grid, defaultOrderBy, logger);
+    }
+
+    private static string? TryInferDefaultOrderBy<TResult>(RadzenDataGrid<TResult> grid) where TResult : notnull
+    {
+        if (grid.ColumnsCollection is null) { return null; }
+
+        var parts = grid.ColumnsCollection
+                        .Where(c => c.SortOrder.HasValue)
+                        .OrderBy(c => c.OrderIndex ?? int.MaxValue)
+                        .Select(c =>
+                        {
+                            var prop = !string.IsNullOrEmpty(c.SortProperty) ? c.SortProperty : c.Property;
+                            if (string.IsNullOrEmpty(prop)) { return null; }
+                            var dir = c.SortOrder == SortOrder.Descending ? "desc" : "asc";
+                            return $"{prop} {dir}";
+                        })
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .ToList();
+
+        return parts.Count == 0 ? null : string.Join(", ", parts);
+    }
+}
+
+public sealed partial class GridLoader<TSource, TResult> : IDisposable
+    where TSource : class
+    where TResult : notnull
+{
+    [GeneratedRegex(@"^[\w\.\s]+(\s+(asc|desc))?(\s*,\s*[\w\.\s]+(\s+(asc|desc))?)*$",
+                    RegexOptions.IgnoreCase)]
+    private static partial Regex OrderByValidationRegex();
+
+    private readonly RadzenDataGrid<TResult> _grid;
+    private readonly string? _defaultOrderBy;
+    private readonly ILogger? _logger;
+
+    private string? _lastFiltersSignature;
+    private int _cachedTotalCount;
+    private ResultLoadData<TResult>? _lastResult;
+    private CancellationTokenSource? _inFlightCts;
+    private Func<List<FilterDescriptor>, Task>? _onFiltersChanged;
+    private Func<IEnumerable<FilterDescriptor>>? _extraFiltersSource;
+
+    internal GridLoader(RadzenDataGrid<TResult> grid,
+                        string? defaultOrderBy,
+                        ILogger? logger)
+    {
+        _grid = grid;
+        _defaultOrderBy = defaultOrderBy;
+        _logger = logger;
+    }
+
+    public void OnFiltersChanged(Func<List<FilterDescriptor>, Task> callback)
+        => _onFiltersChanged = callback;
+
+    public void WithExtraFilters(Func<IEnumerable<FilterDescriptor>> source)
+        => _extraFiltersSource = source;
+
+    public async Task<ResultLoadData<TResult>> LoadAsync(IQueryable<TSource> query,
+                                                         LoadDataArgs args,
+                                                         Expression<Func<TSource, TResult>> selector)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(selector);
+
+        _inFlightCts?.Cancel();
+        _inFlightCts = new CancellationTokenSource();
+        var ct = _inFlightCts.Token;
+
+        var extras = _extraFiltersSource?.Invoke() ?? [];
+        var allFilters = (args.Filters ?? []).Concat(extras).ToList();
+        var signature = ComputeFiltersSignature(allFilters);
+        var filtersChanged = signature != _lastFiltersSignature;
+
+        query = query.AsNoTracking()
+                     .Where(allFilters, _grid.LogicalFilterOperator, _grid.FilterCaseSensitivity);
+
+        int totalCount;
+        if (!filtersChanged)
+        {
+            totalCount = _cachedTotalCount;
+        }
+        else
+        {
+            try
+            {
+                totalCount = await query.CountAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return _lastResult ?? Empty();
+            }
+
+            _lastFiltersSignature = signature;
+            _cachedTotalCount = totalCount;
+        }
+
+        var orderBy = Validate(args.OrderBy) ?? Validate(_defaultOrderBy);
+        if (!string.IsNullOrEmpty(orderBy))
+        {
+            query = query.OrderBy(orderBy);
+        }
+
+        ResultLoadData<TResult> result;
+        try
+        {
+            var items = await query.Select(selector)
+                                   .Skip(args.Skip ?? 0)
+                                   .Take(args.Top ?? 50)
+                                   .ToListAsync(ct);
+            result = new(items, totalCount, args.Filter);
+            _lastResult = result;
+        }
+        catch (OperationCanceledException)
+        {
+            return _lastResult ?? Empty();
+        }
+
+        if (filtersChanged && _onFiltersChanged is not null)
+        {
+            try { await _onFiltersChanged(allFilters); }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Companion OnFiltersChanged callback threw");
+            }
+        }
+
+        return result;
+    }
+
+    public void InvalidateFiltersCache() => _lastFiltersSignature = null;
+
+    public Task RefreshAsync()
+    {
+        InvalidateFiltersCache();
+        return _grid.Reload();
+    }
+
+    public void Dispose()
+    {
+        _inFlightCts?.Cancel();
+        _inFlightCts?.Dispose();
+        _inFlightCts = null;
+    }
+
+    private string? Validate(string? orderBy)
+    {
+        if (string.IsNullOrWhiteSpace(orderBy)) { return null; }
+        if (OrderByValidationRegex().IsMatch(orderBy)) { return orderBy; }
+        _logger?.LogWarning("Potentially unsafe OrderBy clause rejected: {OrderBy}", orderBy);
+        return null;
+    }
+
+    private static string ComputeFiltersSignature(List<FilterDescriptor> filters)
+        => string.Join("|", filters.Select(f =>
+            $"{f.Property}={f.FilterValue}:{f.FilterOperator}:{f.LogicalFilterOperator}"));
+
+    private static ResultLoadData<TResult> Empty() => new([], 0, null);
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/QueryableExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/QueryableExtensions.cs
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 using System.Linq.Expressions;
-using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
 
-public static partial class QueryableExtensions
+public static class QueryableExtensions
 {
-    [GeneratedRegex(@"^[\w\.\s,]+(\s+(asc|desc))?$", RegexOptions.IgnoreCase)]
-    private static partial Regex OrderByValidationRegex();
-
     public static Task<T?> FromIdAsync<T>(this IQueryable<T> source, int id) where T : IId
         => source.Where(a => a.Id == id).FirstOrDefaultAsync();
 
@@ -53,51 +49,4 @@ public static partial class QueryableExtensions
         => condition
             ? source.Where(truePredicate)
             : source.Where(falsePredicate);
-
-    public static async Task<ResultLoadData<TResult>> LoadDataAsync<TSource, TResult>(this IQueryable<TSource> query,
-                                                                                      LoadDataArgs args,
-                                                                                      RadzenDataGrid<TResult> grid,
-                                                                                      Expression<Func<TSource, TResult>> selector,
-                                                                                      string? lastFilter,
-                                                                                      ILogger? logger = null)
-         where TResult : notnull
-         where TSource : class
-    {
-        var skip = args.Skip ?? 0;
-        var take = args.Top ?? 50;
-
-        var newFilter = lastFilter;
-
-        if (!string.IsNullOrEmpty(args.Filter) && lastFilter != args.Filter)
-        {
-            skip = 0;
-            newFilter = args.Filter;
-        }
-
-        query = query.AsNoTracking()
-                     .Where(args.Filters!, grid.LogicalFilterOperator, grid.FilterCaseSensitivity);
-
-        var totalCount = await query.CountAsync();
-
-        // Validate OrderBy to prevent SQL injection via dynamic LINQ
-        if (!string.IsNullOrEmpty(args.OrderBy))
-        {
-            // Basic validation: only allow alphanumeric, dots, spaces, and "asc"/"desc"
-            if (OrderByValidationRegex().IsMatch(args.OrderBy))
-            {
-                query = query.OrderBy(args.OrderBy);
-            }
-            else
-            {
-                logger?.LogWarning("Potentially unsafe OrderBy clause rejected: {OrderBy}", args.OrderBy);
-            }
-        }
-
-        var items = await query.Select(selector)
-                               .Skip(skip)
-                               .Take(take)
-                               .ToListAsync();
-
-        return new(items, totalCount, newFilter);
-    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
@@ -2,8 +2,6 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-using System.Linq.Expressions;
-
 namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
 
 public static class RadzenUIExtensions
@@ -118,15 +116,6 @@ public static class RadzenUIExtensions
                                                 {
                                                     CloseDialogOnOverlayClick = true,
                                                 });
-
-    public static Task<ResultLoadData<TResult>> LoadDataAsync<TSource, TResult>(this RadzenDataGrid<TResult> grid,
-                                                                                IQueryable<TSource> query,
-                                                                                LoadDataArgs args,
-                                                                                Expression<Func<TSource, TResult>> selector,
-                                                                                string? lastFilter)
-       where TResult : notnull
-       where TSource : class
-        => query.LoadDataAsync(args, grid, selector, lastFilter);
 
     public static Task OpenCopyValueAsync(this DialogService dialogService,
                                           string title,

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1053,5 +1053,10 @@
   "Dedicated support": "",
   "option": "",
   "See Pricing": "",
-  "No log entries yet.": ""
+  "No log entries yet.": "",
+  "Last 30 days by status": "",
+  "Vm Name": "",
+  "Parent": "",
+  "Mem. Status": "",
+  "Select all items": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
@@ -18,6 +18,7 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null); private IList<Data> SelectedItems { get; set; } = [];
 
     private bool _validColumnClick;
+    private GridLoader<JobSchedule, Data>? _loader;
 
     private class Data : JobSchedule;
 
@@ -27,35 +28,41 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
         await RefreshDataAsync();
     }
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobSchedule, Data>(DataGridRef, defaultOrderBy: "Label");
+        }
+    }
+
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
         await RefreshDataAsync();
         await InvokeAsync(StateHasChanged);
     }
 
-    public async Task RefreshDataAsync()
-    {
-        if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
-    }
+    public Task RefreshDataAsync()
+        => _loader?.RefreshAsync() ?? (DataGridRef != null ? InvokeAsync(DataGridRef.Reload) : Task.CompletedTask);
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.Jobs.FromClusterName(ClusterName),
-                                                         args,
-                                                         a => new Data
-                                                         {
-                                                             Id = a.Id,
-                                                             Enabled = a.Enabled,
-                                                             VmIds = a.VmIds,
-                                                             Label = a.Label,
-                                                             Description = a.Description,
-                                                             Keep = a.Keep,
-                                                             VmStatus = a.VmStatus,
-                                                             OnlyRuns = a.OnlyRuns,
-                                                             TimeoutSnapshot = a.TimeoutSnapshot
-                                                         },
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.Jobs.FromClusterName(ClusterName),
+                                                 args,
+                                                 a => new Data
+                                                 {
+                                                     Id = a.Id,
+                                                     Enabled = a.Enabled,
+                                                     VmIds = a.VmIds,
+                                                     Label = a.Label,
+                                                     Description = a.Description,
+                                                     Keep = a.Keep,
+                                                     VmStatus = a.VmStatus,
+                                                     OnlyRuns = a.OnlyRuns,
+                                                     TimeoutSnapshot = a.TimeoutSnapshot
+                                                 });
     }
 
     private async Task DeleteAsync()
@@ -139,5 +146,9 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
         }
     }
 
-    public void Dispose() => eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+    public void Dispose()
+    {
+        eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+        _loader?.Dispose();
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Results.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Results.razor.cs
@@ -5,7 +5,7 @@
 namespace Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Components;
 
 public partial class Results(IDbContextFactory<ModuleDbContext> dbContextFactory,
-                             DialogService dialogService) : IClusterName
+                             DialogService dialogService) : IClusterName, IDisposable
 {
     [CascadingParameter(Name = nameof(ClusterName))] public string ClusterName { get; set; } = default!;
     [Parameter] public bool ShowOnlyError { get; set; }
@@ -15,26 +15,37 @@ public partial class Results(IDbContextFactory<ModuleDbContext> dbContextFactory
     private bool _validColumnClick;
     private RadzenDataGrid<Data> DataGridRef { get; set; } = default!;
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null);
+    private GridLoader<JobResult, Data>? _loader;
 
     private class Data : JobResult;
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobResult, Data>(DataGridRef, defaultOrderBy: "Start desc, Id desc");
+        }
+    }
+
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.Results
-                                                           .Where(a => a.Job.Id == JobId, JobId != null)
-                                                           .Where(a => !a.Status, ShowOnlyError),
-                                                         args,
-                                                         a => new Data
-                                                         {
-                                                             Id = a.Id,
-                                                             SnapName = a.SnapName,
-                                                             Status = a.Status,
-                                                             Start = a.Start,
-                                                             End = a.End
-                                                         },
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.Results
+                                                   .Where(a => a.Job.Id == JobId, JobId != null)
+                                                   .Where(a => !a.Status, ShowOnlyError),
+                                                 args,
+                                                 a => new Data
+                                                 {
+                                                     Id = a.Id,
+                                                     SnapName = a.SnapName,
+                                                     Status = a.Status,
+                                                     Start = a.Start,
+                                                     End = a.End
+                                                 });
     }
+
+    public void Dispose() => _loader?.Dispose();
 
     private void CellClick(DataGridCellMouseEventArgs<Data> e)
         => _validColumnClick = new[] { nameof(Data.SnapName) }.Contains(e.Column!.Property);

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
@@ -23,6 +23,7 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null);
     private Settings Settings { get; set; } = new();
     private IEnumerable<VmData> Vms { get; set; } = [];
+    private GridLoader<JobResult, Data>? _loader;
 
     private record VmData(string VmId,
                           string Name,
@@ -47,6 +48,21 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
         await RefreshDataAsync();
     }
 
+    protected override async Task OnParametersSetAsync()
+    {
+        Vms = [.. (await adminService[ClusterName].CachedData.GetResourcesAsync(false))
+                    .Where(a => a.ResourceType == ClusterResourceType.Vm)
+                    .Select(a => new VmData(a.VmId.ToString(), a.Name, a.Description, a.VmType))];
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobResult, Data>(DataGridRef, defaultOrderBy: "Start desc, Id desc");
+        }
+    }
+
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
         await RefreshDataAsync();
@@ -56,33 +72,31 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
     public async Task RefreshDataAsync()
     {
         Settings = settingsService.GetForModule<Module, Settings>(ClusterName);
-        if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
+        if (_loader is not null) { await _loader.RefreshAsync(); }
+        else if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
     }
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
-        Vms = [.. (await adminService[ClusterName].CachedData.GetResourcesAsync(false))
-                    .Where(a => a.ResourceType == ClusterResourceType.Vm)
-                    .Select(a => new VmData(a.VmId.ToString(), a.Name, a.Description, a.VmType))];
+        if (_loader is null) { return; }
 
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.JobResults.Where(a => a.TaskResult.ClusterName == ClusterName),
-                                                         args,
-                                                         a => new Data(Vms)
-                                                         {
-                                                             TaskId = a.TaskResult.TaskId!,
-                                                             Node = a.TaskResult.Node!,
-                                                             Storage = a.TaskResult.Storage!,
-                                                             Archive = a.Archive!,
-                                                             Start = a.Start,
-                                                             End = a.End,
-                                                             Error = a.Error,
-                                                             Size = a.Size,
-                                                             Status = a.Status,
-                                                             TransferSize = a.TransferSize,
-                                                             VmId = a.VmId
-                                                         },
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.JobResults.Where(a => a.TaskResult.ClusterName == ClusterName),
+                                                 args,
+                                                 a => new Data(Vms)
+                                                 {
+                                                     TaskId = a.TaskResult.TaskId!,
+                                                     Node = a.TaskResult.Node!,
+                                                     Storage = a.TaskResult.Storage!,
+                                                     Archive = a.Archive!,
+                                                     Start = a.Start,
+                                                     End = a.End,
+                                                     Error = a.Error,
+                                                     Size = a.Size,
+                                                     Status = a.Status,
+                                                     TransferSize = a.TransferSize,
+                                                     VmId = a.VmId
+                                                 });
     }
 
     private async Task ShowLogAsync(Data item, bool forJob)
@@ -128,5 +142,9 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
         notificationService.Info(L["Scan started!"]);
     }
 
-    public void Dispose() => eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+    public void Dispose()
+    {
+        eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+        _loader?.Dispose();
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Issues.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Issues.razor.cs
@@ -5,7 +5,7 @@
 namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Components;
 
 public partial class Issues(IDbContextFactory<ModuleDbContext> dbContextFactory,
-                            DialogService dialogService) : IClusterName, IRefreshableData
+                            DialogService dialogService) : IClusterName, IRefreshableData, IDisposable
 {
     [CascadingParameter(Name = nameof(ClusterName))] public string ClusterName { get; set; } = default!;
 
@@ -13,17 +13,26 @@ public partial class Issues(IDbContextFactory<ModuleDbContext> dbContextFactory,
     private IList<IgnoredIssue> SelectedItems { get; set; } = [];
     private ResultLoadData<IgnoredIssue> ResultLoadData { get; set; } = new(null!, 0, null);
     private bool _validColumnClick;
+    private GridLoader<IgnoredIssue, IgnoredIssue>? _loader;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<IgnoredIssue, IgnoredIssue>(DataGridRef, defaultOrderBy: "Id");
+        }
+    }
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.IgnoredIssues.FromClusterName(ClusterName),
-                                                         args,
-                                                         a => a,
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.IgnoredIssues.FromClusterName(ClusterName), args, x => x);
     }
 
-    public Task RefreshDataAsync() => DataGridRef.Reload();
+    public Task RefreshDataAsync() => _loader?.RefreshAsync() ?? DataGridRef.Reload();
+
+    public void Dispose() => _loader?.Dispose();
 
     private async Task KeyDownAsync(KeyboardEventArgs e)
     {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -28,6 +28,7 @@ public partial class Scans(IBrowserService browserService,
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null);
 
     private bool _expanded;
+    private GridLoader<JobResult, Data>? _loader;
 
     private record Data(int Id,
                          int Warning,
@@ -48,6 +49,14 @@ public partial class Scans(IBrowserService browserService,
         await RefreshDataAsync();
     }
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobResult, Data>(DataGridRef, defaultOrderBy: "Start desc, Id desc");
+        }
+    }
+
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
         await RefreshDataAsync();
@@ -56,20 +65,18 @@ public partial class Scans(IBrowserService browserService,
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.JobResults
-                                                           .FromClusterName(ClusterName)
-                                                           .Where(a => a.Id == Id, !_expanded && Id != null)
-                                                      ,
-                                                         args,
-                                                         a => new Data(a.Id,
-                                                                       a.Warning,
-                                                                       a.Critical,
-                                                                       a.Info,
-                                                                       a.Start,
-                                                                       a.End),
-                                                         ResultLoadData.Filter);
-
+        ResultLoadData = await _loader.LoadAsync(db.JobResults
+                                                   .FromClusterName(ClusterName)
+                                                   .Where(a => a.Id == Id, !_expanded && Id != null),
+                                                 args,
+                                                 a => new Data(a.Id,
+                                                               a.Warning,
+                                                               a.Critical,
+                                                               a.Info,
+                                                               a.Start,
+                                                               a.End));
     }
 
     private async Task OnGridRenderAsync(DataGridRenderEventArgs<Data> _)
@@ -85,7 +92,8 @@ public partial class Scans(IBrowserService browserService,
     public async Task RefreshDataAsync()
     {
         Settings = settingsService.GetForModule<Module, Settings>(ClusterName);
-        if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
+        if (_loader is not null) { await _loader.RefreshAsync(); }
+        else if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
     }
 
     private async Task DeleteAsync()
@@ -142,5 +150,9 @@ public partial class Scans(IBrowserService browserService,
         notificationService.Info(L["Scan started!"]);
     }
 
-    public void Dispose() => eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+    public void Dispose()
+    {
+        eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+        _loader?.Dispose();
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
@@ -20,6 +20,7 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
     private RadzenDataGrid<Data> DataGridRef { get; set; } = default!;
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null);
     private Settings Settings { get; set; } = new();
+    private GridLoader<JobResult, Data>? _loader;
 
     private class Data : JobResult;
 
@@ -27,6 +28,14 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
     {
         eventNotificationService.Subscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
         await RefreshDataAsync();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobResult, Data>(DataGridRef, defaultOrderBy: "Start desc");
+        }
     }
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
@@ -38,28 +47,29 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
     public async Task RefreshDataAsync()
     {
         Settings = settingsService.GetForModule<Module, Settings>(ClusterName);
-        if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
+        if (_loader is not null) { await _loader.RefreshAsync(); }
+        else if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
     }
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.JobResults.FromClusterName(ClusterName),
-                                                         args,
-                                                         a => new Data
-                                                         {
-                                                             JobId = a.JobId,
-                                                             VmId = a.VmId,
-                                                             Start = a.Start,
-                                                             End = a.End,
-                                                             Source = a.Source,
-                                                             Target = a.Target,
-                                                             Size = a.Size,
-                                                             Status = a.Status,
-                                                             Error = a.Error,
-                                                             LastSync = a.LastSync
-                                                         },
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.JobResults.FromClusterName(ClusterName),
+                                                 args,
+                                                 a => new Data
+                                                 {
+                                                     JobId = a.JobId,
+                                                     VmId = a.VmId,
+                                                     Start = a.Start,
+                                                     End = a.End,
+                                                     Source = a.Source,
+                                                     Target = a.Target,
+                                                     Size = a.Size,
+                                                     Status = a.Status,
+                                                     Error = a.Error,
+                                                     LastSync = a.LastSync
+                                                 });
     }
 
     private async Task ShowLogAsync(Data item)
@@ -90,5 +100,9 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
         notificationService.Info(L["Scan started!"]);
     }
 
-    public void Dispose() => eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+    public void Dispose()
+    {
+        eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+        _loader?.Dispose();
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor
@@ -6,6 +6,11 @@
 @using Corsinvest.ProxmoxVE.Admin.Core.TaskTracking
 @using Corsinvest.ProxmoxVE.Admin.Core.Components.TaskTracking
 
+@if (ChartVisible)
+{
+    <TasksChart Data="@ChartData" ErrorMessage="@ChartError" Loading="@ChartLoading" />
+}
+
 <RadzenDataGrid @ref="@DataGridRef"
                 TItem="TaskItemInfo"
                 Data="@ResultLoadData.Data"
@@ -17,7 +22,7 @@
                 AllowSorting="true"
                 AllowVirtualization="true"
                 AllowColumnPicking="true"
-                Style="height: calc(100vh - 140px)"
+                Style="@($"height: calc(100vh - {(ChartVisible ? 405 : 140)}px);")"
                 FilterPopupRenderMode="PopupRenderMode.OnDemand"
                 FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive">
     <HeaderTemplate>
@@ -28,6 +33,12 @@
                                Properties="@([x => x.Title, x => x.ClusterName, x => x.ModuleName, x => x.Phase, x => x.CreatedBy, x => x.LastLog])"
                                FiltersChanged="OnSearchFiltersChanged"
                                Style="width:260px;" />
+
+                <RadzenButton Icon="@(ChartVisible ? "visibility_off" : "insert_chart")"
+                              Text="@(ChartVisible ? L["Hide chart"] : L["Show chart"])"
+                              ButtonStyle="ButtonStyle.Light"
+                              Size="ButtonSize.Small"
+                              Click="@ToggleChart" />
             </TemplateAfter>
         </CrudToolbar>
     </HeaderTemplate>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor.cs
@@ -13,11 +13,20 @@ public partial class Tasks(ITaskTrackerService taskTracker,
 {
     [Parameter] public string? ClusterName { get; set; }
 
+    private static readonly TimeSpan ChartMaxRange = TimeSpan.FromDays(30);
+
     private RadzenDataGrid<TaskItemInfo> DataGridRef { get; set; } = default!;
     private ResultLoadData<TaskItemInfo> ResultLoadData { get; set; } = new(null!, -1, null);
     private SearchTextBox<TaskItemInfo>? SearchTextBox { get; set; }
     private IReadOnlyList<string> _allowedModules = [];
     private IEnumerable<FilterDescriptor> _searchFilters = [];
+
+    private List<TasksChart.ChartPoint> ChartData { get; set; } = [];
+    private bool ChartVisible { get; set; }
+    private bool ChartLoading { get; set; }
+    private string? ChartError { get; set; }
+
+    private GridLoader<TaskItem, TaskItemInfo>? _loader;
 
     protected override void OnInitialized()
     {
@@ -26,6 +35,27 @@ public partial class Tasks(ITaskTrackerService taskTracker,
                                            .Select(a => a.Name)];
 
         taskTracker.Changed += OnTrackerChanged;
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<TaskItem, TaskItemInfo>(DataGridRef, defaultOrderBy: "StartedAt desc, Id desc");
+
+            _loader.WithExtraFilters(() => _searchFilters);
+
+            _loader.OnFiltersChanged(async filters =>
+            {
+                if (!ChartVisible) { return; }
+                ChartLoading = true;
+                await InvokeAsync(StateHasChanged);
+                await using var db = await dbContextFactory.CreateDbContextAsync();
+                await LoadChartDataAsync(db, filters);
+                ChartLoading = false;
+                await InvokeAsync(StateHasChanged);
+            });
+        }
     }
 
     private void OnTrackerChanged(object? sender, TaskItem e)
@@ -49,44 +79,76 @@ public partial class Tasks(ITaskTrackerService taskTracker,
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-
-        // merge search-box filters with grid filters
-        var mergedFilters = (args.Filters ?? []).Concat(_searchFilters).ToList();
-        args = new LoadDataArgs
-        {
-            Skip = args.Skip,
-            Top = args.Top,
-            OrderBy = args.OrderBy,
-            Filter = args.Filter,
-            Filters = mergedFilters,
-            Sorts = args.Sorts
-        };
-
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.TaskItems
-                                                           .Where(a => a.ModuleName == null || _allowedModules.Contains(a.ModuleName))
-                                                           .Where(a => a.ClusterName == ClusterName, ClusterName is not null),
-                                                         args,
-                                                         a => new TaskItemInfo
-                                                         {
-                                                             Id = a.Id,
-                                                             Title = a.Title,
-                                                             ClusterName = a.ClusterName,
-                                                             ModuleName = a.ModuleName,
-                                                             DetailUrl = a.DetailUrl,
-                                                             IsCancellable = a.IsCancellable,
-                                                             Status = a.Status,
-                                                             Phase = a.Phase,
-                                                             StartedAt = a.StartedAt,
-                                                             EndedAt = a.EndedAt,
-                                                             CreatedBy = a.CreatedBy,
-                                                             Progress = a.Progress,
-                                                             LastLog = a.LastLog,
-                                                         },
-                                                         ResultLoadData.Filter);
+        var query = db.TaskItems
+                      .Where(a => a.ModuleName == null || _allowedModules.Contains(a.ModuleName))
+                      .Where(a => a.ClusterName == ClusterName, ClusterName is not null);
+        ResultLoadData = await _loader.LoadAsync(query,
+                                                 args,
+                                                 a => new TaskItemInfo
+                                                 {
+                                                     Id = a.Id,
+                                                     Title = a.Title,
+                                                     ClusterName = a.ClusterName,
+                                                     ModuleName = a.ModuleName,
+                                                     DetailUrl = a.DetailUrl,
+                                                     IsCancellable = a.IsCancellable,
+                                                     Status = a.Status,
+                                                     Phase = a.Phase,
+                                                     StartedAt = a.StartedAt,
+                                                     EndedAt = a.EndedAt,
+                                                     CreatedBy = a.CreatedBy,
+                                                     Progress = a.Progress,
+                                                     LastLog = a.LastLog,
+                                                 });
     }
 
-    private Task RefreshAsync() => DataGridRef.Reload();
+    private async Task LoadChartDataAsync(ModuleDbContext db, List<FilterDescriptor> filters)
+    {
+        ChartError = null;
+        try
+        {
+            var cutoff = DateTime.UtcNow - ChartMaxRange;
+            var query = db.TaskItems.AsQueryable()
+                                    .Where(a => a.ModuleName == null || _allowedModules.Contains(a.ModuleName))
+                                    .Where(a => a.ClusterName == ClusterName, ClusterName is not null)
+                                    .Where(filters, LogicalFilterOperator.And, FilterCaseSensitivity.CaseInsensitive)
+                                    .Where(a => a.StartedAt >= cutoff);
+
+            ChartData = await query.GroupBy(a => new { a.StartedAt.Date, a.Status })
+                                   .Select(g => new TasksChart.ChartPoint(g.Key.Date, g.Key.Status, g.Count()))
+                                   .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            ChartData = [];
+            ChartError = ex.Message;
+        }
+    }
+
+    private async Task ToggleChart()
+    {
+        ChartVisible = !ChartVisible;
+        if (!ChartVisible) { return; }
+
+        ChartLoading = true;
+        StateHasChanged();
+        await Task.Yield();
+
+        try
+        {
+            await using var db = await dbContextFactory.CreateDbContextAsync();
+            await LoadChartDataAsync(db, [.. _searchFilters]);
+        }
+        finally
+        {
+            ChartLoading = false;
+        }
+    }
+
+    private Task RefreshAsync()
+        => _loader?.RefreshAsync() ?? DataGridRef.Reload();
 
     private async Task OnSearchFiltersChanged(IEnumerable<FilterDescriptor> filters)
     {
@@ -94,5 +156,9 @@ public partial class Tasks(ITaskTrackerService taskTracker,
         await RefreshAsync();
     }
 
-    public void Dispose() => taskTracker.Changed -= OnTrackerChanged;
+    public void Dispose()
+    {
+        taskTracker.Changed -= OnTrackerChanged;
+        _loader?.Dispose();
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/TasksChart.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/TasksChart.razor
@@ -1,0 +1,46 @@
+@*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+*@
+@using Corsinvest.ProxmoxVE.Admin.Core.TaskTracking
+@inherits AdminComponentBase
+
+<RadzenCard class="rz-mb-2">
+    <RadzenText TextStyle="TextStyle.Subtitle2" Text="@L["Last 30 days by status"]" class="rz-mb-1" />
+
+    @if (Loading)
+    {
+        <RadzenProgressBar Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" Style="height:6px" />
+    }
+    else if (!string.IsNullOrEmpty(ErrorMessage))
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Danger" AllowClose="false" Text="@ErrorMessage" />
+    }
+    else if (Data.Count == 0)
+    {
+        <RadzenText TextStyle="TextStyle.Body2" class="rz-p-2" Text="@L["No data for the current filters in the last 30 days."]" />
+    }
+    else
+    {
+        <RadzenChart Style="height:200px;">
+            <RadzenColumnOptions Radius="2" />
+            @foreach (var status in _statuses)
+            {
+                var data = Data.Where(p => p.Status == status).OrderBy(p => p.Day);
+                if (data.Any())
+                {
+                    <RadzenStackedColumnSeries Data="@data"
+                                               CategoryProperty="@nameof(ChartPoint.Day)"
+                                               ValueProperty="@nameof(ChartPoint.Count)"
+                                               Title="@status.ToString()"
+                                               Fill="@StatusColor(status)">
+                        <RadzenColumnOptions Width="20" />
+                    </RadzenStackedColumnSeries>
+                }
+            }
+            <RadzenCategoryAxis FormatString="{0:MM-dd}" />
+            <RadzenValueAxis />
+            <RadzenLegend Position="LegendPosition.Top" />
+        </RadzenChart>
+    }
+</RadzenCard>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/TasksChart.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/TasksChart.razor.cs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using Corsinvest.ProxmoxVE.Admin.Core.TaskTracking;
+
+namespace Corsinvest.ProxmoxVE.Admin.Module.System.TaskTracking.Components;
+
+public partial class TasksChart
+{
+    public record ChartPoint(DateTime Day, TaskItemStatus Status, int Count);
+
+    [Parameter] public List<ChartPoint> Data { get; set; } = [];
+    [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public bool Loading { get; set; }
+
+    private static readonly TaskItemStatus[] _statuses =
+    [
+        TaskItemStatus.Running,
+        TaskItemStatus.Completed,
+        TaskItemStatus.Failed,
+        TaskItemStatus.Cancelled,
+        TaskItemStatus.Abandoned,
+    ];
+
+    private List<ChartPoint>? _lastData;
+    private string? _lastError;
+    private bool _lastLoading;
+
+    protected override bool ShouldRender()
+    {
+        if (ReferenceEquals(_lastData, Data) && _lastError == ErrorMessage && _lastLoading == Loading) { return false; }
+        _lastData = Data;
+        _lastError = ErrorMessage;
+        _lastLoading = Loading;
+        return true;
+    }
+
+    private static string StatusColor(TaskItemStatus status) => status switch
+    {
+        TaskItemStatus.Running => "#1e88e5",       // blue
+        TaskItemStatus.Completed => "#43a047",     // green
+        TaskItemStatus.Failed => "#e53935",        // red
+        TaskItemStatus.Cancelled => "#757575",     // grey
+        TaskItemStatus.Abandoned => "#fb8c00",     // orange
+        _ => "#9e9e9e"
+    };
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
@@ -24,6 +24,7 @@ public partial class Reports(IBrowserService browserService,
     private RadzenDataGrid<Data> DataGridRef { get; set; } = default!;
     private ResultLoadData<Data> ResultLoadData { get; set; } = new(null!, -1, null);
     private bool _validColumnClick;
+    private GridLoader<JobResult, Data>? _loader;
 
     private record Data(int Id,
                         Report.Settings Settings,
@@ -40,6 +41,14 @@ public partial class Reports(IBrowserService browserService,
         await RefreshDataAsync();
     }
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _loader = GridLoader.Create<JobResult, Data>(DataGridRef, defaultOrderBy: "Start desc, Id desc");
+        }
+    }
+
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
         await RefreshDataAsync();
@@ -50,21 +59,19 @@ public partial class Reports(IBrowserService browserService,
 
     private async Task LoadDataAsync(LoadDataArgs args)
     {
+        if (_loader is null) { return; }
         await using var db = await dbContextFactory.CreateDbContextAsync();
-        ResultLoadData = await DataGridRef.LoadDataAsync(db.JobResults.FromClusterName(ClusterName),
-                                                         args,
-                                                         a => new Data(a.Id,
-                                                                       a.Settings,
-                                                                       a.Format,
-                                                                       a.Start,
-                                                                       a.End),
-                                                         ResultLoadData.Filter);
+        ResultLoadData = await _loader.LoadAsync(db.JobResults.FromClusterName(ClusterName),
+                                                 args,
+                                                 a => new Data(a.Id,
+                                                               a.Settings,
+                                                               a.Format,
+                                                               a.Start,
+                                                               a.End));
     }
 
-    public async Task RefreshDataAsync()
-    {
-        if (DataGridRef != null) { await InvokeAsync(DataGridRef.Reload); }
-    }
+    public Task RefreshDataAsync()
+        => _loader?.RefreshAsync() ?? (DataGridRef != null ? InvokeAsync(DataGridRef.Reload) : Task.CompletedTask);
 
     private void CellClick(DataGridCellMouseEventArgs<Data> e)
         => _validColumnClick = e.Column!.Property == nameof(Data.Id);
@@ -153,5 +160,9 @@ public partial class Reports(IBrowserService browserService,
         }
     }
 
-    public void Dispose() => eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+    public void Dispose()
+    {
+        eventNotificationService.Unsubscribe<DataChangedNotification>(HandleDataChangedNotificationAsync);
+        _loader?.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary
- New reusable `GridLoader<TSource, TResult>` abstraction in `Core/Extensions` that encapsulates the boilerplate of paginated Radzen DataGrid loading: filter merging, OrderBy validation with default fallback, total-count caching across virtualization scroll ticks, cancellation of in-flight queries, and a hook for companion queries (charts) that should re-run only when the filter set changes
- New `TasksChart` sub-component on the Tasks page: stacked column chart of the last 30 days grouped by task status, so admins can see at a glance how many tasks ran per day and how they distributed across Running / Completed / Failed / Cancelled / Abandoned
- Migrated grids to GridLoader: AutoSnap (Jobs, Results), BackupAnalytics, Diagnostic (Issues, Scans), ReplicationAnalytics, SystemReport, TaskTracking
- Removed the now-unused `LoadDataAsync` extension methods from `QueryableExtensions` and `RadzenUIExtensions`

## Test plan
- [x] Solution builds clean (0 errors)
- [ ] All migrated grids load correctly with pagination and filtering
- [ ] Virtualization scroll on big tables stays fluid (count cache works)
- [ ] BackupAnalytics: Vms closure still resolved correctly (selector re-evaluated per Load)
- [ ] Tasks page: chart loads on first show with progress bar, hides on toggle