### PR TITLE
fix: show group header totals on outer levels of multi-level groupings

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/ResourcesView.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Common/ResourcesView.razor.cs
@@ -302,17 +302,21 @@ public partial class ResourcesView(IAdminService adminService) : IRefreshableDat
         void GetUsages(IEnumerable<ClusterResource> items)
             => sb.AddRange(items.GetResourceUsage(L).Select(a => $"<strong>{a.Name}</strong>: {a.Usage}%"));
 
-        if (group.Data.Count > 0 && group.Data.Items != null)
+        if (group.Data.Count > 0)
         {
-            var clusterName = group.Data.Items.Cast<ClusterResourceItem>().FirstOrDefault()!.ClusterName;
+            var firstItem = group.Data.FlattenItems<ClusterResourceItem>().FirstOrDefault();
+            if (firstItem is not null)
+            {
+                var clusterName = firstItem.ClusterName;
 
-            if (group.GroupDescriptor!.Property == nameof(IClusterName.ClusterName))
-            {
-                GetUsages(Items.Where(a => a.ClusterName == clusterName));
-            }
-            else if (group.GroupDescriptor.Property == nameof(INode.Node))
-            {
-                GetUsages(Items.Where(a => a.ClusterName == clusterName && a.Node == group.Data.Key));
+                if (group.GroupDescriptor!.Property == nameof(IClusterName.ClusterName))
+                {
+                    GetUsages(Items.Where(a => a.ClusterName == clusterName));
+                }
+                else if (group.GroupDescriptor.Property == nameof(INode.Node))
+                {
+                    GetUsages(Items.Where(a => a.ClusterName == clusterName && a.Node == group.Data.Key));
+                }
             }
         }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor
@@ -23,7 +23,7 @@
                 FilterPopupRenderMode="PopupRenderMode.OnDemand"
                 FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive">
     <GroupHeaderTemplate>
-        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @GetGroupHeader(context)
+        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @FormatHelper.FromBytes(context.Data.FlattenItems<NodeStorageContent>().Sum(a => a.Size))
     </GroupHeaderTemplate>
 
     <Columns>

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/ProxmoxVE/Nodes/StorageContents.razor.cs
@@ -41,11 +41,6 @@ public partial class StorageContents<TItem> where TItem : NodeStorageContent
         if (args.FirstRender) { args.Expanded = false; }
     }
 
-    private static string GetGroupHeader(Group group)
-        => group.Data.Items != null
-            ? FormatHelper.FromBytes(group.Data.Items!.Cast<NodeStorageContent>().Sum(a => a.Size))
-            : string.Empty;
-
     private static FilterMode? GetFilterMode(string propertyName)
         => propertyName switch
         {

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/RadzenUIExtensions.cs
@@ -6,6 +6,21 @@ namespace Corsinvest.ProxmoxVE.Admin.Core.Extensions;
 
 public static class RadzenUIExtensions
 {
+    public static IEnumerable<T> FlattenItems<T>(this GroupResult group)
+    {
+        if (group.Items is not null)
+        {
+            foreach (var item in group.Items.Cast<T>()) { yield return item; }
+        }
+        if (group.Subgroups is not null)
+        {
+            foreach (var sub in group.Subgroups)
+            {
+                foreach (var item in sub.FlattenItems<T>()) { yield return item; }
+            }
+        }
+    }
+
     public static void SetRowStyleError<T>(this RowRenderEventArgs<T> args)
         => args.Attributes.Add("style", $"background-color: {Colors.DangerLight};");
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1058,5 +1058,7 @@
   "Vm Name": "",
   "Parent": "",
   "Mem. Status": "",
-  "Select all items": ""
+  "Select all items": "",
+  "Histories": "",
+  "Select item": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Status.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Status.razor
@@ -47,7 +47,7 @@
                 }
                 else
                 {
-                    @FormatHelper.FromBytes(context.Data.Items!.Cast<AutoSnapInfo>().Sum(a => a.SnapshotsSize))
+                    @FormatHelper.FromBytes(context.Data.FlattenItems<AutoSnapInfo>().Sum(a => a.SnapshotsSize))
                 }
             }
         </RadzenStack>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/_Imports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/_Imports.razor
@@ -6,6 +6,7 @@
 @using Radzen.Blazor
 @using Radzen
 @using Corsinvest.ProxmoxVE.Admin.Core.Components
+@using Corsinvest.ProxmoxVE.Admin.Core.Extensions
 @using Corsinvest.ProxmoxVE.Admin.Core.Models
 @using Corsinvest.ProxmoxVE.Admin.Core.Components.DataGrid
 @using Corsinvest.ProxmoxVE.Admin.Module.AutoSnap.Models

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor
@@ -53,7 +53,7 @@
     </EmptyTemplate>
 
     <GroupHeaderTemplate>
-        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @FormatHelper.FromBytes(context.Data.Items!.Cast<Data>().Sum(a => a.Size))
+        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @FormatHelper.FromBytes(context.Data.FlattenItems<Data>().Sum(a => a.Size))
     </GroupHeaderTemplate>
 
     <Columns>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/_Imports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/_Imports.razor
@@ -6,6 +6,7 @@
 @using Radzen.Blazor
 @using Radzen
 @using Corsinvest.ProxmoxVE.Admin.Core.Components
+@using Corsinvest.ProxmoxVE.Admin.Core.Extensions
 @using Corsinvest.ProxmoxVE.Admin.Core.Models
 @using Corsinvest.ProxmoxVE.Admin.Core.Helpers
 @using Corsinvest.ProxmoxVE.Api.Shared.Models.Node

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor
@@ -55,7 +55,7 @@
         </EmptyTemplate>
 
         <GroupHeaderTemplate>
-            <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data!.Key (@context.Data.Count) @FormatHelper.FromBytes(context.Data.Items!.Cast<Data>().Sum(a => a.Size))
+            <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data!.Key (@context.Data.Count) @FormatHelper.FromBytes(context.Data.FlattenItems<Data>().Sum(a => a.Size))
         </GroupHeaderTemplate>
 
         <Columns>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/_Imports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/_Imports.razor
@@ -6,6 +6,7 @@
 @using Radzen.Blazor
 @using Radzen
 @using Corsinvest.ProxmoxVE.Admin.Core.Components
+@using Corsinvest.ProxmoxVE.Admin.Core.Extensions
 @using Corsinvest.ProxmoxVE.Admin.Core.Models
 @using Corsinvest.ProxmoxVE.Admin.Core.Components.DataGrid
 @using Corsinvest.ProxmoxVE.Api.Shared.Utils

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor
@@ -52,7 +52,7 @@
     </EmptyTemplate>
 
     <GroupHeaderTemplate>
-        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @FormatHelper.FromBytes(context.Data.Items!.Cast<Data>().Sum(a => a.Size))
+        <strong>@context.GroupDescriptor!.GetTitle()</strong>: @context.Data.Key (@context.Data.Count) - <strong>@L["Size"]</strong>: @FormatHelper.FromBytes(context.Data.FlattenItems<Data>().Sum(a => a.Size))
     </GroupHeaderTemplate>
 
     <Columns>

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/_Imports.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/_Imports.razor
@@ -6,6 +6,7 @@
 @using Radzen.Blazor
 @using Radzen
 @using Corsinvest.ProxmoxVE.Admin.Core.Components
+@using Corsinvest.ProxmoxVE.Admin.Core.Extensions
 @using Corsinvest.ProxmoxVE.Admin.Core.Models
 @using Corsinvest.ProxmoxVE.Admin.Core.Helpers
 @using Corsinvest.ProxmoxVE.Api.Shared.Models.Node

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Snapshots.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Resources/Components/Snapshots.razor.cs
@@ -144,9 +144,9 @@ public partial class Snapshots(IAdminService adminService) : IClusterName, IRefr
     private MarkupString GetGroupTitle(Group group)
     {
         var ret = $"<strong>{HtmlEncoder.Default.Encode(group.GroupDescriptor!.GetTitle())}</strong>: {HtmlEncoder.Default.Encode(group.Data.Key?.ToString() ?? "")} ({group.Data.Count})";
-        if (AllowCalculateSnapshotSize && group.Data.Items != null)
+        if (AllowCalculateSnapshotSize)
         {
-            ret += $"- <strong>{L["Size"]}</strong>: {FormatHelper.FromBytes(group.Data.Items.Cast<Data>().Sum(a => a.SnapshotSize))}";
+            ret += $"- <strong>{L["Size"]}</strong>: {FormatHelper.FromBytes(group.Data.FlattenItems<Data>().Sum(a => a.SnapshotSize))}";
         }
 
         return (MarkupString)ret;


### PR DESCRIPTION
## Summary
- Group headers across the app used \`context.Data.Items\` directly, which is **null** when the grid groups by multiple properties — only the innermost groups carry the actual items. As a result outer-level headers showed no totals or resource usage at all (just the group key and count).
- Introduce a small \`GroupResult.FlattenItems<T>()\` extension that walks both \`Items\` and \`Subgroups\` recursively, and switch every offending header to use it.

## Fixed pages
- **Resources → Snapshots**: snapshot size totals now show on every level of the grouping tree
- **Resources** main view: cluster/node group headers now show CPU/disk usage again on outer levels
- **Nodes → Storage contents**: byte totals on outer groups
- **AutoSnap status**, **BackupAnalytics**, **ReplicationAnalytics**, **NodeProtect folder**: size totals on outer groups

## Test plan
- [x] Solution builds clean
- [ ] Open Resources → Snapshots with multi-level grouping (Host → Space → Vm Id → Disk): every outer header shows the aggregated size
- [ ] Open Resources view: cluster/node headers show CPU and disk usage