### PR TITLE
chore(tasks): stream per-step progression logs to the Tasks page

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Helpers/ActionHelper.cs
@@ -25,16 +25,31 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
     {
         var logger = scope.GetLoggerFactory().CreateLogger<ActionHelper>();
         var auditService = scope.GetAuditService();
+        var taskTracker = scope.GetRequiredService<ITaskTrackerService>();
         await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
 
-        using (logger.LogTimeOperation(LogLevel.Information, true, "Delete snapshot {Id}", id))
+        var job = await db.Jobs.FromIdAsync(id);
+        if (job == null)
         {
-            //remove snapshot
-            var job = await db.Jobs.FromIdAsync(id);
-            if (job != null)
+            await db.Jobs.DeleteAsync(id);
+            await PublishDataChangedAsync(scope);
+            return;
+        }
+
+        await using var taskScope = await taskTracker.StartAsync($"AutoSnap delete job [{job.ClusterName}] Job {id} ({job.Label})", job.ClusterName, GetModule(scope).Name, id.ToString());
+        try
+        {
+            using (logger.LogTimeOperation(LogLevel.Information, true, "Delete AutoSnap job {Id}", id))
             {
                 var settings = GetModuleClusterSettings(scope, job.ClusterName);
-                if (settings.OnRemoveJobRemoveSnapshots) { await PurgeAsync(scope, id); }
+                if (settings.OnRemoveJobRemoveSnapshots)
+                {
+                    await PurgeCoreAsync(scope, job, taskScope);
+                }
+
+                taskScope.Item.Phase = "Deleting job";
+                taskScope.Log($"Deleting job {id} ({job.Label}) from cluster {job.ClusterName}, VMs: {job.VmIds}");
+                await db.Jobs.DeleteAsync(id);
 
                 await auditService.LogAsync("AutoSnap.DeleteJob",
                                             true,
@@ -42,16 +57,21 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                             $", Cluster: {job.ClusterName}, " +
                                             $"Label: {job.Label}, " +
                                             $"VMs: {job.VmIds}");
+
+                taskScope.Log($"Job {id} deleted");
+                await PublishDataChangedAsync(scope);
             }
-            await db.Jobs.DeleteAsync(id);
-            await PublishDataChangedAsync(scope);
+        }
+        catch (Exception ex)
+        {
+            taskScope.Item.Status = TaskItemStatus.Failed;
+            taskScope.Log(ex.ToString(), LogLevel.Error);
+            throw;
         }
     }
 
     public static async Task PurgeAsync(IServiceScope scope, int id)
     {
-        var logger = scope.GetLoggerFactory().CreateLogger<ActionHelper>();
-        var auditService = scope.GetAuditService();
         var taskTracker = scope.GetRequiredService<ITaskTrackerService>();
         await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
 
@@ -59,7 +79,24 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
         if (job == null) { return; }
 
         await using var taskScope = await taskTracker.StartAsync($"AutoSnap purge [{job.ClusterName}] Job {id}", job.ClusterName, GetModule(scope).Name, id.ToString());
-        using (logger.LogTimeOperation(LogLevel.Information, true, "Purge snapshot from Job {Id}", id))
+        try
+        {
+            await PurgeCoreAsync(scope, job, taskScope);
+            await PublishDataChangedAsync(scope);
+        }
+        catch
+        {
+            taskScope.Item.Status = TaskItemStatus.Failed;
+            throw;
+        }
+    }
+
+    private static async Task PurgeCoreAsync(IServiceScope scope, JobSchedule job, TaskScope taskScope)
+    {
+        var logger = scope.GetLoggerFactory().CreateLogger<ActionHelper>();
+        var auditService = scope.GetAuditService();
+
+        using (logger.LogTimeOperation(LogLevel.Information, true, "Purge snapshot from Job {Id}", job.Id))
         {
             var settings = GetModuleClusterSettings(scope, job.ClusterName);
             var client = await scope.GetClusterClient(job.ClusterName).GetPveClientAsync();
@@ -68,8 +105,14 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
             try
             {
                 taskScope.Item.Phase = "Purging snapshots";
+                taskScope.Log($"Purging snapshots for job {job.Id} ({job.Label}) on cluster {job.ClusterName}");
 
                 await using var log = new StringWriterEvent();
+                log.WritedData += (_, line) =>
+                {
+                    var trimmed = line?.Trim();
+                    if (!string.IsNullOrEmpty(trimmed)) { taskScope.Log(trimmed); }
+                };
                 var app = GetApp(client, scope.GetLoggerFactory(), log);
 
                 await app.CleanAsync(job.VmIds,
@@ -81,22 +124,19 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
             catch (Exception ex)
             {
                 success = false;
-                taskScope.Item.Status = TaskItemStatus.Failed;
                 taskScope.Log(ex.ToString(), LogLevel.Error);
-                logger.LogError(ex, "Purge failed for Job ID {Id}", id);
+                logger.LogError(ex, "Purge failed for Job ID {Id}", job.Id);
                 throw;
             }
             finally
             {
                 await auditService.LogAsync("AutoSnap.PurgeSnapshots",
                                             success,
-                                            $"Job ID: {id}, " +
+                                            $"Job ID: {job.Id}, " +
                                             $"Cluster: {job.ClusterName}, " +
                                             $"Label: {job.Label}, " +
                                             $"VMs: {job.VmIds.Split(',').Length}");
             }
-
-            await PublishDataChangedAsync(scope);
         }
     }
 
@@ -127,7 +167,12 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 };
 
                 await using var log = new StringWriterEvent();
-                log.WritedData += (_, _) => result.Logs = log.ToString();
+                log.WritedData += (_, line) =>
+                {
+                    result.Logs = log.ToString();
+                    var trimmed = line?.Trim();
+                    if (!string.IsNullOrEmpty(trimmed)) { taskScope.Log(trimmed); }
+                };
 
                 result.Start = DateTime.UtcNow;
                 logger.LogInformation("Execution AutoSnap Job: {Id}", id);
@@ -270,28 +315,59 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
         var logger = scope.GetLoggerFactory().CreateLogger<ActionHelper>();
         var auditService = scope.GetAuditService();
         var commandExecutor = scope.GetCommandExecutor();
+        var taskTracker = scope.GetRequiredService<ITaskTrackerService>();
 
-        using (logger.LogTimeOperation(LogLevel.Information, true, "Execution Delete snapshots"))
+        var snapshotList = snapshots.ToList();
+        var total = snapshotList.Count;
+
+        await using var taskScope = await taskTracker.StartAsync($"AutoSnap delete snapshots [{clusterName}] ({total})", clusterName, GetModule(scope).Name);
+        var failed = 0;
+        try
         {
-            var snapshotList = snapshots.ToList();
-
-            foreach (var item in snapshotList)
+            using (logger.LogTimeOperation(LogLevel.Information, true, "Execution Delete snapshots"))
             {
-                logger.LogInformation("Execution Delete snapshot: {name}", item.Name);
-                var result = await commandExecutor.ExecuteAsync(new VmRemoveSnapshotCommand(clusterName, item.VmId, item.Name, Force: true));
-                if (!result.IsSuccess)
+                taskScope.Item.Phase = $"Deleting {total} snapshot(s)";
+                taskScope.Log($"Deleting {total} snapshot(s) on cluster {clusterName}");
+
+                var index = 0;
+                foreach (var item in snapshotList)
                 {
-                    logger.LogWarning("Delete snapshot failed: {name} ({error})", item.Name, result.ErrorMessage);
+                    index++;
+                    taskScope.Item.Phase = $"Deleting {index}/{total}: VM {item.VmId} '{item.Name}'";
+                    taskScope.Item.Progress = (int)((double)index / total * 100);
+
+                    logger.LogInformation("Execution Delete snapshot: {name}", item.Name);
+                    taskScope.Log($"[{index}/{total}] Deleting snapshot '{item.Name}' on VM {item.VmId}");
+
+                    var result = await commandExecutor.ExecuteAsync(new VmRemoveSnapshotCommand(clusterName, item.VmId, item.Name, Force: true));
+                    if (!result.IsSuccess)
+                    {
+                        failed++;
+                        logger.LogWarning("Delete snapshot failed: {name} ({error})", item.Name, result.ErrorMessage);
+                        taskScope.Log($"  Failed: {result.ErrorMessage}", LogLevel.Warning);
+                    }
                 }
+
+                taskScope.Log(failed == 0
+                                ? $"All {total} snapshot(s) deleted"
+                                : $"Done: {total - failed} deleted, {failed} failed");
+
+                await auditService.LogAsync("AutoSnap.DeleteSnapshots",
+                                            failed == 0,
+                                            $"Cluster: {clusterName}, " +
+                                            $"Count: {total}, " +
+                                            $"Failed: {failed}, " +
+                                            $"Snapshots: {snapshotList.Select(s => $"{s.VmId}:{s.Name}").JoinAsString(", ")}");
             }
 
-            await auditService.LogAsync("AutoSnap.DeleteSnapshots",
-                                        true,
-                                        $"Cluster: {clusterName}, " +
-                                        $"Count: {snapshotList.Count}, " +
-                                        $"Snapshots: {snapshotList.Select(s => $"{s.VmId}:{s.Name}").JoinAsString(", ")}");
+            if (failed > 0) { taskScope.Item.Status = TaskItemStatus.Failed; }
+            await PublishDataChangedAsync(scope);
         }
-
-        await PublishDataChangedAsync(scope);
+        catch (Exception ex)
+        {
+            taskScope.Item.Status = TaskItemStatus.Failed;
+            taskScope.Log(ex.ToString(), LogLevel.Error);
+            throw;
+        }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
@@ -159,7 +159,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
             //list task backup
             var taskItems = await client.Nodes[node.Node].Tasks.GetAsync(typefilter: "vzdump"); //, limit: 9999
-            taskScope?.Log($"  {node.Node}: {taskItems.Count} vzdump task(s) found");
+            taskScope?.Log($"  {node.Node}: {taskItems.Count()} vzdump task(s) found");
 
             // Batch optimization: Load all existing tasks for this node in one query
             var taskIds = taskItems.Select(t => t.UniqueTaskId).ToList();
@@ -232,7 +232,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
             }
 
             await db.SaveChangesAsync();
-            taskScope?.Log($"  {node.Node}: imported {taskItems.Count} task(s)");
+            taskScope?.Log($"  {node.Node}: imported {taskItems.Count()} task(s)");
         }
 
         //remove old logs

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
@@ -143,16 +143,23 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                                                         Settings settings,
                                                                         ModuleDbContext db,
                                                                         bool all,
-                                                                        ILogger logger)
+                                                                        ILogger logger,
+                                                                        TaskScope? taskScope = null)
     {
         const string KEY_STORAGE = "--storage ";
         var taskCount = 0;
         var jobCount = 0;
 
-        foreach (var node in (await client.GetNodesAsync()).Where(a => a.IsOnline))
+        var nodes = (await client.GetNodesAsync()).Where(a => a.IsOnline).ToList();
+        var nodeIndex = 0;
+        foreach (var node in nodes)
         {
+            nodeIndex++;
+            taskScope?.LogProgress(nodeIndex, nodes.Count, $"[{nodeIndex}/{nodes.Count}] Scanning node {node.Node}", phase: $"Scanning {node.Node}");
+
             //list task backup
             var taskItems = await client.Nodes[node.Node].Tasks.GetAsync(typefilter: "vzdump"); //, limit: 9999
+            taskScope?.Log($"  {node.Node}: {taskItems.Count} vzdump task(s) found");
 
             // Batch optimization: Load all existing tasks for this node in one query
             var taskIds = taskItems.Select(t => t.UniqueTaskId).ToList();
@@ -225,14 +232,17 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
             }
 
             await db.SaveChangesAsync();
+            taskScope?.Log($"  {node.Node}: imported {taskItems.Count} task(s)");
         }
 
         //remove old logs
         var minDate = DateTime.UtcNow.AddDays(-settings.MaxDaysLogs);
 
-        await db.TaskResults.FromClusterName(settings.ClusterName)
-                            .Where(a => a.Start < minDate)
-                            .ExecuteDeleteAsync();
+        taskScope?.Log($"Cleaning logs older than {settings.MaxDaysLogs} day(s)");
+        var deleted = await db.TaskResults.FromClusterName(settings.ClusterName)
+                                          .Where(a => a.Start < minDate)
+                                          .ExecuteDeleteAsync();
+        if (deleted > 0) { taskScope?.Log($"Deleted {deleted} old task(s)"); }
 
         return (taskCount, jobCount);
     }
@@ -251,12 +261,14 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
 
                 taskScope.Item.Phase = "Collecting backup data";
+                taskScope.Log($"Collecting backup data for cluster {clusterName}");
 
                 var (taskCount, jobCount) = await ScanAsync(await scope.GetClusterClient(clusterName).GetPveClientAsync(),
                                                             GetModuleSettings(scope, clusterName),
                                                             db,
                                                             false,
-                                                            logger);
+                                                            logger,
+                                                            taskScope);
 
                 taskScope.Item.Phase = "Saving results";
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Helpers/ActionHelper.cs
@@ -31,6 +31,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
 
                 taskScope.Item.Phase = "Loading ignored issues";
+                taskScope.Log($"Loading ignored issues for cluster {clusterName}");
 
                 var ignoredIssues = db.IgnoredIssues
                                       .FromClusterName(clusterName)
@@ -44,11 +45,15 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                       })
                                       .ToList();
 
+                taskScope.Log($"Loaded {ignoredIssues.Count} ignored issue(s)");
+
                 var now = DateTime.UtcNow;
 
                 taskScope.Item.Phase = "Analyzing cluster";
+                taskScope.Log($"Analyzing cluster {clusterName}");
 
                 var client = await scope.GetClusterClient(clusterName).GetPveClientAsync();
+                var analyzeStart = DateTime.UtcNow;
                 var details = (await new DiagnosticEngine(client, settings.ApiSettings, httpClientFactory.CreateClient())
                                         .AnalyzeAsync(ignoredIssues))
                                         .Select(a => new JobDetail
@@ -70,7 +75,10 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
                 int Count(DiagnosticResultGravity gravity) => details.Count(a => a.Gravity == gravity && !a.IsIgnoredIssue);
 
+                taskScope.Log($"Analysis completed in {(DateTime.UtcNow - analyzeStart).TotalSeconds:F1}s: {details.Count} check(s), Critical={Count(DiagnosticResultGravity.Critical)}, Warning={Count(DiagnosticResultGravity.Warning)}, Info={Count(DiagnosticResultGravity.Info)}");
+
                 taskScope.Item.Phase = "Saving results";
+                taskScope.Log("Saving results");
 
                 var jobResult = new JobResult
                 {
@@ -85,6 +93,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
                 await db.JobResults.AddAsync(jobResult);
                 await db.SaveChangesAsync();
+                taskScope.Log($"Saved scan result ID {jobResult.Id}");
 
                 taskScope.Item.ReferenceId = jobResult.Id.ToString();
                 taskScope.Item.DetailUrl = QueryHelpers.AddQueryString(GetModule(scope).LinkMain!.GetRealUrl(clusterName),
@@ -98,12 +107,17 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                                              .Select(a => a.Id)
                                              .ToListAsync();
 
-                await db.JobResults.Where(a => ids.Contains(a.Id)).ExecuteDeleteAsync();
+                if (ids.Count > 0)
+                {
+                    var deleted = await db.JobResults.Where(a => ids.Contains(a.Id)).ExecuteDeleteAsync();
+                    taskScope.Log($"Deleted {deleted} old scan result(s) (keep={settings.Keep})");
+                }
 
                 //send notification
                 taskScope.Item.Phase = "Sending notifications";
                 if (settings.NotifierConfigurations?.Any() is true && (settings.NotifyPdf || settings.NotifyExcel))
                 {
+                    taskScope.Log($"Sending notification (PDF={settings.NotifyPdf}, Excel={settings.NotifyExcel})");
                     var diagnosticService = scope.GetRequiredService<IDiagnosticService>();
 
                     var resultForReport = new JobResult

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Migrations/20260530200118_AddJobDetailCompliance.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Migrations/20260530200118_AddJobDetailCompliance.cs
@@ -3,70 +3,69 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Migrations
+namespace Corsinvest.ProxmoxVE.Admin.Module.Diagnostic.Migrations;
+
+/// <inheritdoc />
+public partial class AddJobDetailCompliance : Migration
 {
     /// <inheritdoc />
-    public partial class AddJobDetailCompliance : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<string>(
-                name: "ErrorCode",
-                schema: "diagnostic",
-                table: "JobDetails",
-                type: "text",
-                nullable: false,
-                defaultValue: "",
-                collation: "case_insensitive");
+        migrationBuilder.AddColumn<string>(
+            name: "ErrorCode",
+            schema: "diagnostic",
+            table: "JobDetails",
+            type: "text",
+            nullable: false,
+            defaultValue: "",
+            collation: "case_insensitive");
 
-            migrationBuilder.CreateTable(
-                name: "JobDetailCompliances",
-                schema: "diagnostic",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "integer", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    JobDetailId = table.Column<int>(type: "integer", nullable: false),
-                    Standard = table.Column<int>(type: "integer", nullable: false),
-                    ControlId = table.Column<string>(type: "text", nullable: false, collation: "case_insensitive")
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_JobDetailCompliances", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_JobDetailCompliances_JobDetails_JobDetailId",
-                        column: x => x.JobDetailId,
-                        principalSchema: "diagnostic",
-                        principalTable: "JobDetails",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+        migrationBuilder.CreateTable(
+            name: "JobDetailCompliances",
+            schema: "diagnostic",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                JobDetailId = table.Column<int>(type: "integer", nullable: false),
+                Standard = table.Column<int>(type: "integer", nullable: false),
+                ControlId = table.Column<string>(type: "text", nullable: false, collation: "case_insensitive")
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_JobDetailCompliances", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_JobDetailCompliances_JobDetails_JobDetailId",
+                    column: x => x.JobDetailId,
+                    principalSchema: "diagnostic",
+                    principalTable: "JobDetails",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_JobDetailCompliances_JobDetailId",
-                schema: "diagnostic",
-                table: "JobDetailCompliances",
-                column: "JobDetailId");
+        migrationBuilder.CreateIndex(
+            name: "IX_JobDetailCompliances_JobDetailId",
+            schema: "diagnostic",
+            table: "JobDetailCompliances",
+            column: "JobDetailId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_JobDetailCompliances_Standard",
-                schema: "diagnostic",
-                table: "JobDetailCompliances",
-                column: "Standard");
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_JobDetailCompliances_Standard",
+            schema: "diagnostic",
+            table: "JobDetailCompliances",
+            column: "Standard");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "JobDetailCompliances",
-                schema: "diagnostic");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "JobDetailCompliances",
+            schema: "diagnostic");
 
-            migrationBuilder.DropColumn(
-                name: "ErrorCode",
-                schema: "diagnostic",
-                table: "JobDetails");
-        }
+        migrationBuilder.DropColumn(
+            name: "ErrorCode",
+            schema: "diagnostic",
+            table: "JobDetails");
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Helpers/ActionHelper.cs
@@ -16,7 +16,8 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
     private static async Task<(int JobCount, int SuccessCount, int FailureCount)> ScanAsync(PveClient client,
                                                                                            Settings settings,
                                                                                            ModuleDbContext db,
-                                                                                           ILogger logger)
+                                                                                           ILogger logger,
+                                                                                           TaskScope? taskScope = null)
     {
         const string KEY_SIZE = ": total estimated size is";
         var jobCount = 0;
@@ -25,9 +26,15 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
 
         static DateTime ParseDateTime(string value) => DateTime.ParseExact(value, "yyyy-MM-dd HH:mm:ss", null);
 
-        foreach (var node in (await client.GetNodesAsync()).Where(a => a.IsOnline))
+        var nodes = (await client.GetNodesAsync()).Where(a => a.IsOnline).ToList();
+        var nodeIndex = 0;
+        foreach (var node in nodes)
         {
+            nodeIndex++;
+            taskScope?.LogProgress(nodeIndex, nodes.Count, $"[{nodeIndex}/{nodes.Count}] Scanning node {node.Node}", phase: $"Scanning {node.Node}");
+
             var jobs = await client.Nodes[node.Node].Replication.GetAsync();
+            taskScope?.Log($"  {node.Node}: {jobs.Count} replication job(s) found");
 
             // Batch optimization: Load all existing jobs for this node in one query
             var jobKeys = jobs.Select(j => new
@@ -137,11 +144,13 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 await using var db = await scope.GetDbContextAsync<ModuleDbContext>();
 
                 taskScope.Item.Phase = "Collecting replication data";
+                taskScope.Log($"Collecting replication data for cluster {clusterName}");
 
                 var (jobCount, successCount, failureCount) = await ScanAsync(await scope.GetClusterClient(clusterName).GetPveClientAsync(),
                                                                               GetModuleSettings(scope, clusterName),
                                                                               db,
-                                                                              logger);
+                                                                              logger,
+                                                                              taskScope);
 
                 taskScope.Item.Phase = "Saving results";
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Helpers/ActionHelper.cs
@@ -34,7 +34,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
             taskScope?.LogProgress(nodeIndex, nodes.Count, $"[{nodeIndex}/{nodes.Count}] Scanning node {node.Node}", phase: $"Scanning {node.Node}");
 
             var jobs = await client.Nodes[node.Node].Replication.GetAsync();
-            taskScope?.Log($"  {node.Node}: {jobs.Count} replication job(s) found");
+            taskScope?.Log($"  {node.Node}: {jobs.Count()} replication job(s) found");
 
             // Batch optimization: Load all existing jobs for this node in one query
             var jobKeys = jobs.Select(j => new


### PR DESCRIPTION
## Summary
Several background actions (AutoSnap purge, BackupAnalytics scan, ReplicationAnalytics scan, Diagnostic scan) opened a \`taskScope\` and only set \`Item.Phase\` between steps, with a single \`Log\` line at the end. Phase changes alone are not persisted nor pushed to the live UI: only \`AddLog\` / \`SetProgress\` / \`LogProgress\` trigger the \`Updated\` event that flushes logs to the DB and raises \`TaskTracker.Changed\`.

As a result the **Tasks page** looked frozen on "Running" until the action ended.

This wires per-step \`Log\` / \`LogProgress\` calls in every offending path so the user sees the action progressing in real time.

### Changes
- **AutoSnap purge**: forward each line from the AutoSnapEngine stream writer to taskScope (same trick already used by snap)
- **AutoSnap snap**: also stream the engine output live (was previously only captured into \`result.Logs\`)
- **BackupAnalytics scan**: log per-node progress and counts
- **ReplicationAnalytics scan**: log per-node progress and counts
- **Diagnostic scan**: log macro-phases (loaded ignored issues, analyzed in Xs, saved result, cleanup, notification)
- Drive-by: drop the wrapping namespace block in the \`AddJobDetailCompliance\` EF migration to silence IDE0161

## Test plan
- [x] Solution builds clean
- [ ] Open Tasks page in one tab, trigger a Diagnostic / BackupAnalytics / ReplicationAnalytics / AutoSnap purge from another tab — log entries appear in the task detail as they happen