### PR TITLE
chore: align .editorconfig end_of_line with .gitattributes (lf)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 spelling_exclusion_path = spelling.dic
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-end_of_line = crlf
+end_of_line = lf
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_object_initializer = true:warning
@@ -49,7 +49,7 @@ roslynator_analyzers.enabled_by_default = true
 [*.cs]
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+end_of_line = lf
 dotnet_diagnostic.IDE0059.severity = warning
 dotnet_diagnostic.IDE0060.severity = warning
 dotnet_diagnostic.CS0168.severity = warning
@@ -373,5 +373,5 @@ end_of_line = lf
 [*.{razor,cshtml}]
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8-bom


### PR DESCRIPTION
## Summary
\`.gitattributes\` already mandates LF on commit but \`.editorconfig\` forced VS and \`dotnet format\` to write CRLF on Windows checkouts. Every formatter run produced noisy \"388 files changed\" diffs that were only line ending conversions.

Align the three \`end_of_line = crlf\` entries in \`.editorconfig\` (\`[*]\`, \`[*.cs]\`, \`[*.{razor,cshtml}]\`) to \`lf\` so the two configs agree. Working copy on Windows is unaffected: git keeps doing the LF↔CRLF transparently on checkout.

## Test plan
- [x] No code changes
- [ ] On Windows: \`git status\` stays clean after a \`dotnet format\` pass