### PR TITLE
chore(autosnap): enqueue manual scan jobs immediately, drop 5s delay

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
@@ -74,7 +74,7 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
             await using var db = await dbContextFactory.CreateDbContextAsync();
             await db.Jobs.DeleteAsync(SelectedItems[0].Id);
 
-            backgroundJobService.Schedule<Job>(a => a.DeleteAsync(SelectedItems[0].Id), TimeSpan.FromSeconds(5));
+            backgroundJobService.Enqueue<Job>(a => a.DeleteAsync(SelectedItems[0].Id));
             notificationService.Info(L["Delete started!"]);
 
             SelectedItems.Clear();
@@ -105,14 +105,14 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
     {
         if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Clean selected row"], false))
         {
-            backgroundJobService.Schedule<Job>(a => a.PurgeAsync(SelectedItems[0].Id), TimeSpan.FromSeconds(5));
+            backgroundJobService.Enqueue<Job>(a => a.PurgeAsync(SelectedItems[0].Id));
             notificationService.Info(L["Purge started!"]);
         }
     }
 
     private void Snap()
     {
-        backgroundJobService.Schedule<Job>(a => a.SnapAsync(SelectedItems[0].Id), TimeSpan.FromSeconds(5));
+        backgroundJobService.Enqueue<Job>(a => a.SnapAsync(SelectedItems[0].Id));
         notificationService.Info(L["Job started!"]);
     }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Status.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Status.razor.cs
@@ -126,7 +126,7 @@ public partial class Status(IAdminService adminService,
 
         if (await dialogService.ConfirmAsync(L["Are you sure?"], L["Delete selected rows"], true))
         {
-            backgroundJobService.Schedule<Job>(a => a.DeleteAsync(SelectedItems, ClusterName), TimeSpan.FromSeconds(5));
+            backgroundJobService.Enqueue<Job>(a => a.DeleteAsync(SelectedItems, ClusterName));
             notificationService.Info(L["Deleting snapshots started!"]);
             SelectedItems.Clear();
         }


### PR DESCRIPTION
## Summary
UI-triggered AutoSnap actions (Snap, Purge, Delete job, Delete snapshots from the Status grid) used to schedule the background job with a 5-second delay. The user clicked, nothing visible happened for 5s, and only then the task appeared in the Tasks list — confusing UX.

Switch to immediate \`Enqueue\` so the job appears in Tasks the moment the confirmation dialog is accepted.

## Affected actions
- AutoSnap Jobs: Snap, Purge, Delete (per-job)
- AutoSnap Status: Delete (bulk snapshot delete)

## Test plan
- [x] Solution builds clean
- [ ] Click Snap / Purge / Delete on an AutoSnap job: the task appears immediately in System → Tasks
- [ ] Bulk delete snapshots from Status: the task appears immediately