### PR TITLE
feat(security): built-in system user + propagated permission fix + Hangfire user context

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Commands/Models/PveTaskResult.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Commands/Models/PveTaskResult.cs
@@ -23,11 +23,11 @@ public record PveTaskResult : CommandResult<Result>
         };
 
     public static PveTaskResult Failure(string clusterName, string errorMessage)
-        => (PveTaskResult)CommandResult<Result>.Failure(errorMessage) with { ClusterName = clusterName };
+        => new() { Status = CommandResultStatus.Failed, ErrorMessage = errorMessage, ClusterName = clusterName };
 
     public static new PveTaskResult Forbidden(string clusterName)
-        => (PveTaskResult)CommandResult<Result>.Forbidden() with { ClusterName = clusterName };
+        => new() { Status = CommandResultStatus.Forbidden, ErrorMessage = "Operation not permitted", ClusterName = clusterName };
 
     public static new PveTaskResult Unauthorized(string clusterName)
-        => (PveTaskResult)CommandResult<Result>.Unauthorized() with { ClusterName = clusterName };
+        => new() { Status = CommandResultStatus.Unauthorized, ErrorMessage = "Authentication required", ClusterName = clusterName };
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/IdentityExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Extensions/IdentityExtensions.cs
@@ -97,7 +97,7 @@ public static class IdentityExtensions
             await permissionService.AddForRoleAsync(role.Id, permissions.Select(a => new PermissionData(ApplicationHelper.AllClusterName,
                                                                                                         a.Key,
                                                                                                         "*",
-                                                                                                        false,
+                                                                                                        true,
                                                                                                         role.BuiltIn)));
         }
     }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Auth/IAuditService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Auth/IAuditService.cs
@@ -8,7 +8,5 @@ public interface IAuditService
 {
     Type Render { get; }
 
-    Task LogAsync(string userName, string action, bool success, string? details = null);
-
     Task LogAsync(string action, bool success, string? details = null);
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/ApplicationUser.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/ApplicationUser.cs
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Identity;
 
 namespace Corsinvest.ProxmoxVE.Admin.Core.Security.Identity;
@@ -12,6 +13,9 @@ public class ApplicationUser : IdentityUser, IBuiltIn
     public bool IsActive { get; set; } = true;
     public string? ProfileImageUrl { get; set; }
     public bool BuiltIn { get; set; }
+
+    [NotMapped]
+    public bool IsSystem => UserName == SystemUser.UserName;
 
     public static string GetUserProfileImagePath(string email) => Path.Combine(ApplicationHelper.UserProfileImagesPath, $"{email}.jpg");
     public virtual ICollection<UserPermission> UserPermissions { get; set; } = [];

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/SystemUser.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/SystemUser.cs
@@ -15,4 +15,5 @@ public static class SystemUser
     public const string UserName = "system";
     public const string DisplayName = "System";
     public const string Email = "system@cv4pve-admin.invalid";
+    public static string Id { get; set; } = string.Empty;
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/SystemUser.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Security/Identity/SystemUser.cs
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace Corsinvest.ProxmoxVE.Admin.Core.Security.Identity;
+
+/// <summary>
+/// Special built-in user used by background jobs and other non-HTTP execution
+/// contexts (Hangfire cron, hosted services, workflow timers). It has full
+/// permissions but cannot log in: created locked-out with no password and an
+/// unroutable email address.
+/// </summary>
+public static class SystemUser
+{
+    public const string UserName = "system";
+    public const string DisplayName = "System";
+    public const string Email = "system@cv4pve-admin.invalid";
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Security/UserCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Security/UserCommands.cs
@@ -76,6 +76,12 @@ public static class UserCommands
                 return 1;
             }
 
+            if (user.IsSystem)
+            {
+                Console.WriteLine($"Error: User '{username}' is a system user and cannot be modified");
+                return 1;
+            }
+
             // Reset password
             var token = await userManager.GeneratePasswordResetTokenAsync(user);
             var result = await userManager.ResetPasswordAsync(user, token, password);
@@ -112,6 +118,12 @@ public static class UserCommands
                 return 1;
             }
 
+            if (user.IsSystem)
+            {
+                Console.WriteLine($"Error: User '{username}' is a system user and cannot be unlocked");
+                return 1;
+            }
+
             var result = await userManager.SetLockoutEndDateAsync(user, null);
             if (!result.Succeeded)
             {
@@ -140,6 +152,12 @@ public static class UserCommands
             if (user == null)
             {
                 Console.WriteLine($"Error: User '{username}' not found");
+                return 1;
+            }
+
+            if (user.IsSystem)
+            {
+                Console.WriteLine($"Error: User '{username}' is a system user and cannot be modified");
                 return 1;
             }
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1060,5 +1060,10 @@
   "Mem. Status": "",
   "Select all items": "",
   "Histories": "",
-  "Select item": ""
+  "Select item": "",
+  "Delete selected rows": "",
+  "Deleting snapshots started!": "",
+  "Only set": "",
+  "The system account cannot be deleted.": "",
+  "The system account cannot be modified.": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1065,5 +1065,7 @@
   "Deleting snapshots started!": "",
   "Only set": "",
   "The system account cannot be deleted.": "",
-  "The system account cannot be modified.": ""
+  "The system account cannot be modified.": "",
+  "Run retention cleanup now?": "",
+  "Deleted {0} record(s)": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/LogJobFilter.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/LogJobFilter.cs
@@ -10,7 +10,7 @@ using Hangfire.Storage;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.System.BackgroundJobs.Filters;
 
-public class LogJobFilter : IClientFilter, IServerFilter, IElectStateFilter, IApplyStateFilter
+public class LogJobFilter(IServiceProvider serviceProvider) : IClientFilter, IServerFilter, IElectStateFilter, IApplyStateFilter
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
@@ -23,10 +23,19 @@ public class LogJobFilter : IClientFilter, IServerFilter, IElectStateFilter, IAp
                              context.BackgroundJob?.Id);
 
     public void OnPerforming(PerformingContext context)
-        => Logger.InfoFormat("Starting to perform job {0}", context.BackgroundJob.Id);
+        => Logger.InfoFormat("Starting to perform job {0} as user '{1}'",
+                             context.BackgroundJob.Id,
+                             GetExecutingUser());
 
     public void OnPerformed(PerformedContext context)
-        => Logger.InfoFormat("Job {0} has been performed", context.BackgroundJob.Id);
+        => Logger.InfoFormat("Job {0} has been performed by user '{1}'",
+                             context.BackgroundJob.Id,
+                             GetExecutingUser());
+
+    // UserContextJobFilter runs before this one and populates HttpContext.User
+    // with the principal of the user running the job (or the system user).
+    private string? GetExecutingUser()
+        => serviceProvider.GetService<IHttpContextAccessor>()?.HttpContext?.User?.Identity?.Name;
 
     public void OnStateElection(ElectStateContext context)
     {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/UserContextJobFilter.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/UserContextJobFilter.cs
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+using Hangfire.Client;
+using Hangfire.Server;
+
+namespace Corsinvest.ProxmoxVE.Admin.Module.System.BackgroundJobs.Filters;
+
+public class UserContextJobFilter(IServiceProvider serviceProvider) : IClientFilter, IServerFilter
+{
+    private const string ParameterName = "UserId";
+
+    public void OnCreating(CreatingContext context)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var current = scope.ServiceProvider.GetService<ICurrentUserService>();
+
+        var userId = current?.UserId;
+        if (!string.IsNullOrEmpty(userId)) { context.SetJobParameter(ParameterName, userId); }
+    }
+
+    public void OnCreated(CreatedContext context)
+    {
+
+    }
+
+    public void OnPerforming(PerformingContext context)
+    {
+        var userId = context.GetJobParameter<string>(ParameterName);
+
+        var scope = serviceProvider.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        // No HTTP user at schedule time (cron, hosted service): run as system.
+        var effectiveId = string.IsNullOrEmpty(userId)
+                            ? SystemUser.Id
+                            : userId;
+        var user = userManager.FindByIdAsync(effectiveId).GetAwaiter().GetResult();
+
+        if (user is null)
+        {
+            scope.Dispose();
+            return;
+        }
+
+        var signInManager = scope.ServiceProvider.GetRequiredService<SignInManager<ApplicationUser>>();
+        var principal = signInManager.CreateUserPrincipalAsync(user).GetAwaiter().GetResult();
+
+        var httpContextAccessor = scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            User = principal,
+            RequestServices = scope.ServiceProvider,
+        };
+
+        // Keep the scope alive for the duration of the job; disposed in OnPerformed.
+        context.Items["UserContextScope"] = scope;
+    }
+
+    public void OnPerformed(PerformedContext context)
+    {
+        if (context.Items.TryGetValue("UserContextScope", out var scopeObj) && scopeObj is IServiceScope scope)
+        {
+            scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext = null;
+            scope.Dispose();
+            context.Items.Remove("UserContextScope");
+        }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/ServiceCollectionExtensions.cs
@@ -31,12 +31,18 @@ internal static class ServiceCollectionExtensions
         GlobalJobFilters.Filters.Add(new PreventConcurrentExecutionWithJobAndArgsFilter());
 
         //services.AddSingleton<JobActivator, JobActivatorEx>();
-        services.AddHangfire(config =>
+        services.AddHangfire((sp, config) =>
         {
+            var diagLogger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("HangfireConfig");
+            diagLogger.LogWarning("===== AddHangfire lambda executing — registering custom filters =====");
+
             config.UsePostgreSqlStorage(options => options.UseNpgsqlConnection(configuration.GetConnectionString("DefaultConnection")),
                                                                                new PostgreSqlStorageOptions { SchemaName = "hangfire" });
 
-            config.UseFilter(new LogJobFilter());
+            // UserContextJobFilter must run before LogJobFilter so the log
+            // entries see the principal populated by the former.
+            config.UseFilter(new UserContextJobFilter(sp));
+            config.UseFilter(new LogJobFilter(sp));
             // config.UseFilter(new SkipConcurrentExecutionFilter(provider.GetRequiredService<ILogger<SkipConcurrentExecutionFilter>>()));
             config.UseColouredConsoleLogProvider();
             config.UseRecommendedSerializerSettings();
@@ -52,6 +58,21 @@ internal static class ServiceCollectionExtensions
     {
         using var scope = app.Services.CreateScope();
         var appSettings = scope.GetRequiredService<ISettingsService>().GetAppSettings();
+
+        // Fallback: if AddHangfire lambda was bypassed (e.g. Elsa starts its
+        // own Hangfire server before our config runs), our filters never get
+        // registered. Add them here against the live application provider.
+        var logger = scope.GetRequiredService<ILoggerFactory>().CreateLogger("HangfireConfig");
+        if (!GlobalJobFilters.Filters.Select(f => f.Instance).OfType<UserContextJobFilter>().Any())
+        {
+            logger.LogWarning("UserContextJobFilter not registered — adding via fallback on app.Services");
+            GlobalJobFilters.Filters.Add(new UserContextJobFilter(app.Services));
+            GlobalJobFilters.Filters.Add(new LogJobFilter(app.Services));
+        }
+        else
+        {
+            logger.LogInformation("UserContextJobFilter already registered via AddHangfire lambda");
+        }
 
         app.MapHangfireDashboard(BackgroundJobsDashboardUrl,
                                  new DashboardOptions

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/EndpointRouteBuilderExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Components/EndpointRouteBuilderExtensions.cs
@@ -129,22 +129,22 @@ public static class EndpointRouteBuilderExtensions
 
             if (result.Succeeded)
             {
-                await auditService.LogAsync(userName.Value, "Login-TwoFactor", true);
+                await auditService.LogAsync("Login-TwoFactor", true, $"User '{userName.Value}' logged in");
                 url = tmpReturnUrl;
             }
             else if (result.IsLockedOut)
             {
-                await auditService.LogAsync(userName.Value, "Login-TwoFactor", false, "Account locked out");
+                await auditService.LogAsync("Login-TwoFactor", false, $"Account locked out for user '{userName.Value}'");
                 url = BuildErrorUrl(tmpReturnUrl, "This account has been locked out, please try again later");
             }
             else if (result.IsNotAllowed)
             {
-                await auditService.LogAsync(userName.Value, "Login-TwoFactor", false, "Account not allowed");
+                await auditService.LogAsync("Login-TwoFactor", false, $"Account not allowed for user '{userName.Value}'");
                 url = BuildErrorUrl(tmpReturnUrl, "This account is not allowed, please try again later");
             }
             else
             {
-                await auditService.LogAsync(userName.Value, "Login-TwoFactor", false, "Invalid authenticator code");
+                await auditService.LogAsync("Login-TwoFactor", false, $"Invalid authenticator code for user '{userName.Value}'");
                 url = BuildErrorUrl(tmpReturnUrl, "Invalid authenticator code entered");
             }
 
@@ -167,7 +167,7 @@ public static class EndpointRouteBuilderExtensions
             var result = await signInManager.PasswordSignInExAsync(model.UserName, model.Password, model.RememberMe, true);
             if (result.Succeeded)
             {
-                await auditService.LogAsync(model.UserName, "Login-Password", true);
+                await auditService.LogAsync("Login-Password", true, $"User '{model.UserName}' logged in");
 
                 var userSettings = settingsService.Get<UserSettings>(forCurrentUser: true);
                 httpContext.Response.AppendCultureCookie(userSettings.Culture);
@@ -187,17 +187,17 @@ public static class EndpointRouteBuilderExtensions
             }
             else if (result.IsLockedOut)
             {
-                await auditService.LogAsync(model.UserName, "Login-Password", false, "Account locked out");
+                await auditService.LogAsync("Login-Password", false, $"Account locked out for user '{model.UserName}'");
                 url = BuildErrorUrl(tmpReturnUrl, "This account has been locked out, please try again later");
             }
             else if (result.IsNotAllowed)
             {
-                await auditService.LogAsync(model.UserName, "Login-Password", false, "Account not allowed");
+                await auditService.LogAsync("Login-Password", false, $"Account not allowed for user '{model.UserName}'");
                 url = BuildErrorUrl(tmpReturnUrl, "This account is not allowed, please try again later");
             }
             else
             {
-                await auditService.LogAsync(model.UserName, "Login-Password", false, "Invalid credentials");
+                await auditService.LogAsync("Login-Password", false, $"Invalid credentials for user '{model.UserName}'");
                 url = BuildErrorUrl(tmpReturnUrl, "Invalid user or password");
             }
 
@@ -212,7 +212,7 @@ public static class EndpointRouteBuilderExtensions
             var userName = context.User?.Identity?.Name;
             await signInManager.SignOutAsync();
 
-            if (!string.IsNullOrEmpty(userName)) { await auditService.LogAsync(userName, "Logout", true); }
+            if (!string.IsNullOrEmpty(userName)) { await auditService.LogAsync("Logout", true, $"User '{userName}' logged out"); }
 
             return TypedResults.LocalRedirect($"~{SanitizeReturnUrl(returnUrl)}");
         });

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
@@ -106,6 +106,8 @@ public static class ServiceCollectionExtensions
         var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(Module));
         logger.LogDebug("Initialize Security db");
 
+        await ApplyBackwardCompatFixesAsync(services, logger);
+
         var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
         var adminUser = await userManager.FindByEmailAsync(ApplicationHelper.DefaultAdminUsername);
         if (adminUser == null)
@@ -142,6 +144,7 @@ public static class ServiceCollectionExtensions
             //no password: cannot log in
             await userManager.CreateAsync(systemUser);
         }
+        SystemUser.Id = systemUser.Id;
 
         var roleManager = services.GetRequiredService<RoleManager<ApplicationRole>>();
         var permissionService = services.GetRequiredService<IPermissionService>();
@@ -189,6 +192,28 @@ public static class ServiceCollectionExtensions
             {
                 await roleManager.CreateAsync(item, permissionService);
             }
+        }
+    }
+
+    /// <summary>
+    /// Run all idempotent backward-compat data fixes for older installations.
+    /// Add new sub-fixes here when historical bugs leave stale rows that need
+    /// realignment at boot. Each sub-fix must be safe to run on already-fixed
+    /// or fresh databases (no-op when nothing matches).
+    /// </summary>
+    private static async Task ApplyBackwardCompatFixesAsync(IServiceProvider services, ILogger logger)
+    {
+        await using var db = await services.GetRequiredService<IDbContextFactory<ModuleDbContext>>().CreateDbContextAsync();
+
+        // Builtin role permissions with Path="*" were seeded with
+        // Propagated=false, which broke checks against specific paths (e.g.
+        // /vms/1000). New rows are now written with Propagated=true.
+        var propagatedRows = await db.RolePermissions
+                                     .Where(r => r.BuiltIn && r.Path == "*" && !r.Propagated)
+                                     .ExecuteUpdateAsync(s => s.SetProperty(r => r.Propagated, true));
+        if (propagatedRows > 0)
+        {
+            logger.LogInformation("Realigned {Rows} builtin role permission(s) to Propagated=true", propagatedRows);
         }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/ServiceCollectionExtensions.cs
@@ -124,11 +124,40 @@ public static class ServiceCollectionExtensions
             await userManager.CreateAsync(adminUser, ApplicationHelper.DefaultUserPassword);
         }
 
-        var roleManager = services.GetRequiredService<RoleManager<ApplicationRole>>();
-        await roleManager.CreateAsync(RoleConstants.AdministratorRole, "Admin", true, false);
-        await userManager.AddToRolesAsync(adminUser, [RoleConstants.AdministratorRole]);
+        var systemUser = await userManager.FindByNameAsync(SystemUser.UserName);
+        if (systemUser == null)
+        {
+            systemUser = new ApplicationUser
+            {
+                UserName = SystemUser.UserName,
+                IsActive = true,
+                DisplayName = SystemUser.DisplayName,
+                Email = SystemUser.Email,
+                EmailConfirmed = false,
+                BuiltIn = true,
+                LockoutEnabled = true,
+                LockoutEnd = DateTimeOffset.MaxValue,
+            };
 
+            //no password: cannot log in
+            await userManager.CreateAsync(systemUser);
+        }
+
+        var roleManager = services.GetRequiredService<RoleManager<ApplicationRole>>();
         var permissionService = services.GetRequiredService<IPermissionService>();
+
+        await AddSystemRolesAsync(userManager, roleManager, permissionService, services, adminUser);
+        await AddSystemRolesAsync(userManager, roleManager, permissionService, services, systemUser);
+    }
+
+    private static async Task AddSystemRolesAsync(UserManager<ApplicationUser> userManager,
+                                                  RoleManager<ApplicationRole> roleManager,
+                                                  IPermissionService permissionService,
+                                                  IServiceProvider services,
+                                                  ApplicationUser user)
+    {
+        await roleManager.CreateAsync(RoleConstants.AdministratorRole, "Admin", true, false);
+        await userManager.AddToRolesAsync(user, [RoleConstants.AdministratorRole]);
 
         var roles = new[]
         {
@@ -141,7 +170,7 @@ public static class ServiceCollectionExtensions
         foreach (var item in roles)
         {
             var role = await roleManager.CreateAsync(item, permissionService);
-            await userManager.AddToRoleAsync(adminUser, role.Name!);
+            await userManager.AddToRoleAsync(user, role.Name!);
 
             if (ClusterPermissions.RoleAdmin == item)
             {
@@ -153,7 +182,7 @@ public static class ServiceCollectionExtensions
         //create roles for module
         foreach (var module in services.GetRequiredService<IModuleService>().Modules)
         {
-            await userManager.AddToRoleAsync(adminUser, (await roleManager.CreateAsync(module.RoleAdmin, permissionService)).Name!);
+            await userManager.AddToRoleAsync(user, (await roleManager.CreateAsync(module.RoleAdmin, permissionService)).Name!);
 
             //role and permission specific module
             foreach (var item in module.AllRoles)

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Services/AuditService.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/Security/Services/AuditService.cs
@@ -6,12 +6,13 @@ using Corsinvest.ProxmoxVE.Admin.Core.Security.Auth;
 
 namespace Corsinvest.ProxmoxVE.Admin.Module.System.Security.Services;
 
-public class AuditService(ILogger<AuditService> logger, IHttpContextAccessor httpContextAccessor) : IAuditService
+public class AuditService(ILogger<AuditService> logger, ICurrentUserService currentUserService) : IAuditService
 {
     public Type Render { get; } = typeof(Core.Components.SubscriptionRequired);
 
-    public Task LogAsync(string userName, string action, bool success, string? details = null)
+    public Task LogAsync(string action, bool success, string? details = null)
     {
+        var userName = currentUserService.UserName;
         if (success)
         {
             logger.LogInformation("Successful {Action} for user: {UserName}. Details: {Details}", action, userName, details);
@@ -23,7 +24,4 @@ public class AuditService(ILogger<AuditService> logger, IHttpContextAccessor htt
 
         return Task.CompletedTask;
     }
-
-    public Task LogAsync(string action, bool success, string? details = null)
-        => LogAsync(httpContextAccessor.HttpContext?.User?.Identity?.Name ?? "System", action, success, details);
 }

--- a/src/Corsinvest.ProxmoxVE.Admin/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin/Program.cs
@@ -20,9 +20,16 @@ var (_, extraSettingsWarning) = builder.Configuration.AddJsonFileSafe(Path.Combi
 // Add service defaults & Aspire client integrations.
 builder.AddServiceAspireDefaults();
 
+// Surface sink errors to stderr instead of swallowing them.
+Serilog.Debugging.SelfLog.Enable(Console.Error);
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .CreateLogger();
+
 builder.Host.UseSerilog((_, config) => config.ReadFrom.Configuration(builder.Configuration));
 
-Log.Logger.Information("Start cv4pve-admin....");
+Log.Logger.Information("========== Start cv4pve-admin ==========");
 Log.Logger.Information("Version: {Version}", BuildInfo.Version);
 if (extraSettingsWarning != null) { Log.Logger.Warning(extraSettingsWarning); }
 


### PR DESCRIPTION
## Summary

This branch closes the loop on the **built-in `system` user** introduced previously and fixes several issues uncovered while wiring it into the background job pipeline.

- Builtin role permissions are now seeded with `Propagated=true` (older DBs are realigned at boot via an idempotent backward-compat fix).
- Hangfire jobs now run with the identity of the user who scheduled them — or with the builtin `system` user when no HTTP context exists (cron, hosted services).
- `IAuditService.LogAsync(userName, ...)` overload removed; the username for login attempts is embedded in the audit `details` so all other call sites can stay clean and source the user from `ICurrentUserService`.
- `PveTaskResult` static factories no longer crash with `InvalidCastException` at runtime.
- Serilog now surfaces sink errors instead of swallowing them silently.

## Commits

1. `fix(security): seed builtin role permissions with Propagated=true`
2. `feat(jobs): propagate user context into Hangfire job execution`
3. `refactor(audit): drop userName overload, source from ICurrentUserService`
4. `fix(commands): construct PveTaskResult directly to avoid invalid cast`
5. `chore(logging): enable Serilog SelfLog and bootstrap logger at startup`

(plus `feat(security): introduce built-in system user` already on the branch)

## Test plan

- [ ] Boot on a fresh DB: `system` user is created, has all admin roles, cannot log in.
- [ ] Boot on an existing DB with `Propagated=false` rows: log shows `Realigned N builtin role permission(s) to Propagated=true`.
- [ ] Schedule an AutoSnap delete from the UI: job runs as the triggering user, audit log records the real user.
- [ ] Trigger a cron-scheduled job: runs as `system`, no `Permission denied`.
- [ ] Login with valid credentials: audit log shows `Login-Password` with username in details; login with invalid: shows failure reason in details.
- [ ] PVE command that returns `Failure` / `Forbidden` / `Unauthorized`: no `InvalidCastException`.
- [ ] Force a Serilog sink misconfiguration: stderr surfaces the error.