### PR TITLE
feat(ui): status badge in Tasks page + cleanup post system-user merge

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1067,5 +1067,6 @@
   "The system account cannot be deleted.": "",
   "The system account cannot be modified.": "",
   "Run retention cleanup now?": "",
-  "Deleted {0} record(s)": ""
+  "Deleted {0} record(s)": "",
+  "Failed": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/UserContextJobFilter.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/Filters/UserContextJobFilter.cs
@@ -20,10 +20,7 @@ public class UserContextJobFilter(IServiceProvider serviceProvider) : IClientFil
         if (!string.IsNullOrEmpty(userId)) { context.SetJobParameter(ParameterName, userId); }
     }
 
-    public void OnCreated(CreatedContext context)
-    {
-
-    }
+    public void OnCreated(CreatedContext context) { }
 
     public void OnPerforming(PerformingContext context)
     {

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/ServiceCollectionExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/BackgroundJobs/ServiceCollectionExtensions.cs
@@ -33,9 +33,6 @@ internal static class ServiceCollectionExtensions
         //services.AddSingleton<JobActivator, JobActivatorEx>();
         services.AddHangfire((sp, config) =>
         {
-            var diagLogger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("HangfireConfig");
-            diagLogger.LogWarning("===== AddHangfire lambda executing — registering custom filters =====");
-
             config.UsePostgreSqlStorage(options => options.UseNpgsqlConnection(configuration.GetConnectionString("DefaultConnection")),
                                                                                new PostgreSqlStorageOptions { SchemaName = "hangfire" });
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor
@@ -52,7 +52,18 @@
 
         <RadzenDataGridColumn Property="@nameof(TaskItemInfo.ClusterName)" Title="@L["Cluster"]"  Width="140px" FilterMode="FilterMode.CheckBoxList" />
         <RadzenDataGridColumn Property="@nameof(TaskItemInfo.ModuleName)"  Title="@L["Module"]"   Width="140px" FilterMode="FilterMode.CheckBoxList" />
-        <RadzenDataGridColumn Property="@nameof(TaskItemInfo.Status)"      Title="@L["Status"]"   Width="110px" FilterMode="FilterMode.CheckBoxList" />
+
+        <RadzenDataGridColumn Property="@nameof(TaskItemInfo.Status)"      Title="@L["Status"]"   Width="130px" FilterMode="FilterMode.CheckBoxList">
+            <Template Context="item">
+                <RadzenBadge BadgeStyle="@GetStatusBadgeStyle(item.Status)"
+                             IsPill="true"
+                             Shade="Shade.Lighter">
+                    <RadzenIcon Icon="@GetStatusIcon(item.Status)" Style="font-size:14px;vertical-align:middle;margin-right:4px;" />
+                    @item.Status
+                </RadzenBadge>
+            </Template>
+        </RadzenDataGridColumn>
+
         <RadzenDataGridColumn Property="@nameof(TaskItemInfo.StartedAt)"   Title="@L["Started"]"  Width="150px" FormatString="{0:g}" SortOrder="SortOrder.Descending"/>
         <RadzenDataGridColumn Property="@nameof(TaskItemInfo.Duration)"    Title="@L["Duration"]" Width="100px" FormatString="{0:hh':'mm':'ss}" Filterable="false" />
 

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.System/TaskTracking/Components/Tasks.razor.cs
@@ -161,4 +161,24 @@ public partial class Tasks(ITaskTrackerService taskTracker,
         taskTracker.Changed -= OnTrackerChanged;
         _loader?.Dispose();
     }
+
+    private static string GetStatusIcon(TaskItemStatus status) => status switch
+    {
+        TaskItemStatus.Running => "autorenew",
+        TaskItemStatus.Completed => "check_circle",
+        TaskItemStatus.Failed => "error",
+        TaskItemStatus.Cancelled => "cancel",
+        TaskItemStatus.Abandoned => "report_problem",
+        _ => "circle"
+    };
+
+    private static BadgeStyle GetStatusBadgeStyle(TaskItemStatus status) => status switch
+    {
+        TaskItemStatus.Running => BadgeStyle.Info,
+        TaskItemStatus.Completed => BadgeStyle.Success,
+        TaskItemStatus.Failed => BadgeStyle.Danger,
+        TaskItemStatus.Cancelled => BadgeStyle.Secondary,
+        TaskItemStatus.Abandoned => BadgeStyle.Warning,
+        _ => BadgeStyle.Light
+    };
 }


### PR DESCRIPTION
## Summary

- **Tasks page**: status column now uses a pill badge with icon (Running/Completed/Failed/Cancelled/Abandoned), matching the badge style of the EE Logs Level column for visual consistency.
- **Background jobs**: drop the diagnostic boot warning that was added to validate the Elsa Hangfire override fix; tighten an empty filter body kept on purpose.

## Test plan

- [ ] Tasks page (`/module/*/system/tasks`): status column shows colored pill with icon.
- [ ] Boot logs: no more "AddHangfire lambda executing" warning.
- [ ] AutoSnap job runs without issues (filters still applied via fallback in `MapBackgroundJobsAdmin`).