### PR TITLE
chore: release 2.1.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.1.0-rc4] - 2026-06-23
+
+### Changed
+
+- **Module Overview pages**. Every module landing page now opens with the existing three-column intro plus a small dashboard built from the module's own widgets — no more *Overview* tabs that only show decorative text. Modules that have nothing meaningful to show as widgets (e.g. **Resources**) keep the textual overview as before.
+
+- **Issue cards on the *AutoSnap*, *Backup Analytics*, *Replication Analytics*, *Diagnostic* and *Resources* widgets**. The old "thumb up / thumb down + bullet list" has been redesigned: when everything is fine you see a green thumb up, when there are issues a red thumb down with a number, and when the module is not configured a neutral icon with an explanatory message. Hovering the number opens a compact list of the failing items; each row is clickable and takes you straight to the relevant detail page (the failing VM, the offline node, the diagnostic scan, etc.). With many rows the list scrolls inside itself instead of growing without bound.
+
+- **Diagnostic issue labels**. The items on the *Diagnostic* widget used to be shown as internal paths that were hard to read. They now read *VM 100 on cc01 (cluster)*, *Node cc01 (cluster)*, *Storage ssd-pool (cluster)* and so on.
+
+### Fixed
+
+- **KPI cards in the *Snapshot Statistics and Insights* widget**. The four KPI tiles at the top of the widget kept stacking vertically even on large screens because the layout did not adapt correctly to desktop window sizes. They now stay horizontal as soon as there is room for them.
+
 ## [2.1.0-rc3] - 2026-06-05
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
 
   <!-- Version and Package Info -->
   <PropertyGroup>
-  <Version>2.1.0-rc3</Version>
+  <Version>2.1.0-rc4</Version>
 
     <!-- Pre-release/Testing detection -->
     <VersionPreRelease>$([System.Text.RegularExpressions.Regex]::Match($(Version), '-(.+)$').Groups[1].Value)</VersionPreRelease>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,12 +2,12 @@
   <ItemGroup>
     <PackageVersion Include="Corsinvest.ProxmoxVE.NodeProtect.Api" Version="2.1.1" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="2.5.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="6.2.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
@@ -17,18 +17,18 @@
   <ItemGroup>
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <!-- UI and Frontend -->
   <ItemGroup>
-    <PackageVersion Include="Radzen.Blazor" Version="10.4.7" />
+    <PackageVersion Include="Radzen.Blazor" Version="10.4.9" />
     <PackageVersion Include="OpenLayers.Blazor" Version="2.5.0" />
   </ItemGroup>
   <!-- Utilities and Tools -->
@@ -36,11 +36,11 @@
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
     <PackageVersion Include="ClosedXML.Report" Version="0.2.12" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
-    <PackageVersion Include="Mapster" Version="10.0.7" />
+    <PackageVersion Include="Mapster" Version="10.0.9" />
     <PackageVersion Include="PDFsharp-MigraDoc" Version="6.2.4" />
     <PackageVersion Include="BlazorDownloadFile" Version="2.4.0.2" />
     <PackageVersion Include="FluentResults" Version="4.0.0" />
-    <PackageVersion Include="CronExpressionDescriptor" Version="2.48.0" />
+    <PackageVersion Include="CronExpressionDescriptor" Version="2.50.0" />
     <PackageVersion Include="cronos" Version="0.13.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
     <!-- 3.1.12: latest 3.x (Apache-2.0) with all known CVEs fixed.
@@ -49,14 +49,14 @@
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.9" />
   </ItemGroup>
   <!-- Scheduling and Background Jobs -->
   <ItemGroup>
     <PackageVersion Include="Hangfire" Version="1.8.23" />
     <PackageVersion Include="Hangfire.Console" Version="1.4.3" />
-    <PackageVersion Include="Hangfire.Console.Extensions" Version="2.1.0" />
-    <PackageVersion Include="Hangfire.Console.Extensions.Serilog" Version="2.1.0" />
+    <PackageVersion Include="Hangfire.Console.Extensions" Version="2.1.2" />
+    <PackageVersion Include="Hangfire.Console.Extensions.Serilog" Version="2.1.2" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
   </ItemGroup>
   <!-- Proxmox VE -->
@@ -73,8 +73,8 @@
   </ItemGroup>
   <!-- MCP Server -->
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Wangkanai.Detection" Version="8.20.0" />

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Cuts release candidate **2.1.0-rc4**.

### Highlights

- Module landing pages now show a small dashboard built from the module's own widgets (PR #331).
- Issue badges on AutoSnap / Backup Analytics / Replication Analytics / Diagnostic / Resources redesigned: thumb up/down with a numeric badge and a hover popup that lists the failing items as clickable rows linking to the detail page.
- Diagnostic widget items shown as readable labels (*VM 100 on cc01 (cluster)*) instead of internal paths.
- Fixed KPI tiles in the *Snapshot Statistics and Insights* widget that kept stacking on large screens.

### Dependency bumps

- EF Core 10.0.8 → 10.0.9
- Microsoft.Extensions.ServiceDiscovery 10.6.0 → 10.7.0
- Serilog.Settings.Configuration 10.0.0 → 10.0.1
- Aspire Hosting 13.4.0 → 13.4.6

## Test plan

- [ ] Module overview pages show the mini-dashboard (AutoSnap, BackupAnalytics, ReplicationAnalytics, Diagnostic, NodeProtect, Updater).
- [ ] Resources overview shows only the textual intro.
- [ ] AutoSnap.Check widget: thumb-up when ok, thumb-down + numeric badge when issues, neutral icon when not configured.
- [ ] Hover badge opens popup, click row navigates to detail page.
- [ ] Diagnostic widget items show readable labels.
- [ ] Snapshot Statistics widget shows 4 KPI horizontal on desktop.
- [ ] All existing pages still render after the rename Text/Block of Overview3Cols slots.