### PR TITLE
fix(backup-analytics): convert failed-at timestamp to UTC before saving

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Helpers/ActionHelper.cs
@@ -98,7 +98,7 @@ internal class ActionHelper : BaseActionHelper<Module, Settings, DataChangedNoti
                 else if (row.StartsWith(KEY_FAILED))
                 {
                     backup.Status = false;
-                    backup.Start = ParseDateBackup(row[KEY_FAILED.Length..]);
+                    backup.Start = DateTime.SpecifyKind(ParseDateBackup(row[KEY_FAILED.Length..]), DateTimeKind.Local).ToUniversalTime();
                     backup.End = backup.Start;
                     backups.Add(backup);
                 }


### PR DESCRIPTION
## Summary

The vzdump task log line *Failed at 2026-06-20 22:00:16* was parsed as a `DateTime` with `Kind=Unspecified` and assigned directly to the result entity. Npgsql refused to save it because the column is `timestamp with time zone`, which only accepts UTC values, and the whole scan aborted with:

> `System.ArgumentException: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported.`

Trigger: any vzdump run with at least one failed backup (e.g. a VM locked by a snapshot).

## Fix

Wrap the parsed value with `DateTime.SpecifyKind(.., DateTimeKind.Local).ToUniversalTime()`, same as the three sibling branches that parse `Backup started at` / `Backup finished at` / `ending archive` (already correct).

Verified that **ReplicationAnalytics** and **AutoSnap** do not have the same pattern — both already save UTC values.

## Test plan

- [ ] Run a Backup Analytics scan on a cluster with at least one failed backup in the recent vzdump tasks.
- [ ] The scan completes without `DbUpdateException`.
- [ ] The failed backup shows up in the Backups grid with the correct timestamp (local time of the PVE node, displayed in the user's local time).