### PR TITLE
chore: release 2.1.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.1.0-rc5] - 2026-06-23
+
+### Fixed
+
+- **Backup Analytics scan**. The scan aborted in the middle when at least one vzdump task in the run had failed (e.g. a VM locked by a snapshot). The failed task is now imported correctly together with the successful ones.
+
 ## [2.1.0-rc4] - 2026-06-23
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
 
   <!-- Version and Package Info -->
   <PropertyGroup>
-  <Version>2.1.0-rc4</Version>
+  <Version>2.1.0-rc5</Version>
 
     <!-- Pre-release/Testing detection -->
     <VersionPreRelease>$([System.Text.RegularExpressions.Regex]::Match($(Version), '-(.+)$').Groups[1].Value)</VersionPreRelease>


### PR DESCRIPTION
Cuts release candidate 2.1.0-rc5.

Includes the backup-analytics fix from PR #333: scan no longer aborts when a vzdump task in the run has failed.