### PR TITLE
docs: remove shop.corsinvest.it links

### DIFF
--- a/docs/README.dockerhub.md
+++ b/docs/README.dockerhub.md
@@ -25,7 +25,6 @@ Access at `http://localhost:8080` — default: `admin@local` / `Password123!`
 
 - 📖 [Documentation](https://corsinvest.github.io/cv4pve-admin/)
 - 📋 [CE vs EE Comparison](https://corsinvest.github.io/cv4pve-admin/editions/)
-- 🛒 [Get Enterprise License](https://shop.corsinvest.it/store/cv4pve-admin-pve)
 - 🌐 [www.corsinvest.it](https://www.corsinvest.it)
 
 *Proxmox® is a registered trademark of Proxmox Server Solutions GmbH.*

--- a/docs/user/docs/editions.md
+++ b/docs/user/docs/editions.md
@@ -30,7 +30,7 @@ Choose the edition that fits your needs: free and open source Community Edition 
 </div>
 
 <div style="margin-top: auto;">
-<a href="https://shop.corsinvest.it" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise →</strong></a>
+<a href="getting-started.md" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise (Free) →</strong></a>
 </div>
 
 </div>
@@ -134,7 +134,7 @@ Expert technical assistance<br>
 </div>
 
 <div style="margin-top: auto;">
-<a href="https://shop.corsinvest.it" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise →</strong></a>
+<a href="getting-started.md" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise (Free) →</strong></a>
 </div>
 
 </div>
@@ -199,7 +199,7 @@ Mission-critical operations<br>
 </div>
 
 <div style="margin-top: auto;">
-<a href="https://shop.corsinvest.it" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise →</strong></a>
+<a href="getting-started.md" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise (Free) →</strong></a>
 </div>
 
 </div>
@@ -245,7 +245,7 @@ Optional addon modules</p>
 </div>
 
 <div style="margin-top: auto;">
-<a href="https://shop.corsinvest.it" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise →</strong></a>
+<a href="getting-started.md" class="md-button md-button--primary" style="display: inline-block;"><strong>Get Enterprise (Free) →</strong></a>
 </div>
 
 </div>


### PR DESCRIPTION
EE distribution is currently free while the licensing portal is under construction. Removing all shop CTAs from the user docs (`editions.md`) and the Docker Hub readme; the CTAs in `editions.md` now point to `getting-started.md`.

## Test plan

- [ ] Render docs with mkdocs and confirm no shop.corsinvest.it link remains
- [ ] Docker Hub readme renders without the shop bullet