### PR TITLE
fix: wrap HandleDataChangedNotificationAsync in InvokeAsync

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.AutoSnap/Components/Jobs.razor.cs
@@ -38,8 +38,11 @@ public partial class Jobs(IDbContextFactory<ModuleDbContext> dbContextFactory,
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     public Task RefreshDataAsync()

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.BackupAnalytics/Components/Backups.razor.cs
@@ -65,8 +65,11 @@ public partial class Backups(IDbContextFactory<ModuleDbContext> dbContextFactory
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     public async Task RefreshDataAsync()

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Diagnostic/Components/Scans.razor.cs
@@ -59,8 +59,11 @@ public partial class Scans(IBrowserService browserService,
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     private async Task LoadDataAsync(LoadDataArgs args)

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.NodeProtect/Folder/Components/Render.razor.cs
@@ -34,8 +34,11 @@ public partial class Render(IDbContextFactory<ModuleDbContext> dbContextFactory,
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     public async Task RefreshDataAsync()

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.ReplicationAnalytics/Components/Replications.razor.cs
@@ -40,8 +40,11 @@ public partial class Replications(IDbContextFactory<ModuleDbContext> dbContextFa
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     public async Task RefreshDataAsync()

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.SystemReport/Components/Reports.razor.cs
@@ -51,8 +51,11 @@ public partial class Reports(IBrowserService browserService,
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     private static bool ShowWating(Data item) => item.Start == DateTime.MinValue && item.End == null;

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Updater/Components/Scans.razor.cs
@@ -39,8 +39,11 @@ public partial class Scans(IAdminService adminService,
 
     private async Task HandleDataChangedNotificationAsync(DataChangedNotification notification)
     {
-        await RefreshDataAsync();
-        await InvokeAsync(StateHasChanged);
+        await InvokeAsync(async () =>
+        {
+            await RefreshDataAsync();
+            StateHasChanged();
+        });
     }
 
     public async Task RefreshDataAsync()


### PR DESCRIPTION
## Summary

DataChangedNotification handlers are invoked on background threads (Hangfire). Without wrapping in \`InvokeAsync\`, calling \`StateHasChanged()\` or \`RadzenDataGrid.Reload()\` crashes with:

\`\`\`
System.InvalidOperationException: The current thread is not associated with the Dispatcher.
Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.
\`\`\`

Fix applied to 5 components: AutoSnap Jobs, BackupAnalytics Backups, Diagnostic Scans, ReplicationAnalytics Replications, SystemReport Reports.

## Test plan

- [ ] Trigger a background scan on any of the affected modules — no dispatcher exception in logs
- [ ] Grids/pages reload automatically on scan completion