### PR TITLE
fix(dashboard): disable Save button when Name is empty

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Dashboard/Components/Dashboard.razor
@@ -16,6 +16,7 @@
                           Text="@L["Save"]"
                           Icon="save"
                           Click="SaveAsync"
+                          Disabled="@string.IsNullOrWhiteSpace(CurrentDashboard?.Name)"
                           ButtonStyle="ButtonStyle.Primary" />
 
             <RadzenButton Variant="Variant.Text"


### PR DESCRIPTION
Prevents saving a dashboard with a null Name, which caused a Postgres NOT NULL constraint violation when clicking Save without filling the name field.