### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,13 +2,13 @@
   <ItemGroup>
     <PackageVersion Include="Corsinvest.ProxmoxVE.NodeProtect.Api" Version="2.1.1" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Report" Version="2.5.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="6.2.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="ToonEncoder" Version="2.0.0" />
@@ -20,36 +20,36 @@
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
   </ItemGroup>
   <!-- UI and Frontend -->
   <ItemGroup>
-    <PackageVersion Include="Radzen.Blazor" Version="11.1.6" />
+    <PackageVersion Include="Radzen.Blazor" Version="11.2.7" />
     <PackageVersion Include="OpenLayers.Blazor" Version="2.6.0" />
   </ItemGroup>
   <!-- Utilities and Tools -->
   <ItemGroup>
-    <PackageVersion Include="ClosedXML" Version="0.105.0" />
+    <PackageVersion Include="ClosedXML" Version="0.105.1" />
     <PackageVersion Include="ClosedXML.Report" Version="0.2.12" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
-    <PackageVersion Include="Mapster" Version="10.0.11" />
+    <PackageVersion Include="Mapster" Version="10.0.12" />
     <PackageVersion Include="PDFsharp-MigraDoc" Version="6.2.4" />
     <PackageVersion Include="BlazorDownloadFile" Version="2.4.0.2" />
     <PackageVersion Include="FluentResults" Version="4.0.0" />
     <PackageVersion Include="CronExpressionDescriptor" Version="2.51.0" />
     <PackageVersion Include="cronos" Version="0.13.0" />
-    <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
+    <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.7.1" />
     <!-- 3.1.12: latest 3.x (Apache-2.0) with all known CVEs fixed.
          DO NOT upgrade to v4.x: switched to Six Labors Split License (commercial). -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="[3.1.12]" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>
   <!-- Scheduling and Background Jobs -->
   <ItemGroup>
@@ -73,8 +73,8 @@
   </ItemGroup>
   <!-- MCP Server -->
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
+    <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Wangkanai.Detection" Version="8.20.0" />

--- a/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
+++ b/src/Corsinvest.ProxmoxVE.Admin.AppHost/Corsinvest.ProxmoxVE.Admin.AppHost.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.3" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.5.3" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.MailPit" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Routine dependency bump across the solution.

### Runtime and framework
- EF Core and ASP.NET Core Identity/Diagnostics `10.0.10` → `10.0.11`
- `Microsoft.Extensions.ServiceDiscovery` `10.8.0` → `10.9.0`
- Aspire hosting (AppHost, PostgreSQL) `13.4.6` → `13.5.3`, MailPit `13.4.0` → `13.5.0`
- OpenTelemetry exporter and instrumentation `1.17.0` → `1.18.0`

### UI
- `Radzen.Blazor` `11.1.6` → `11.2.7`

### Libraries and tooling
- `ModelContextProtocol` / `ModelContextProtocol.AspNetCore` `1.4.1` → `2.2.0`
- `SSH.NET` `2025.1.0` → `2026.0.0`
- `ZiggyCreatures.FusionCache` `2.6.0` → `2.7.1`
- `ClosedXML` `0.105.0` → `0.105.1`
- `Mapster` `10.0.11` → `10.0.12`
- `System.CommandLine` `2.0.10` → `2.0.11`

### Notes
- `SixLabors.ImageSharp` stays pinned to `[3.1.12]`: the 4.x line moved to the Six Labors Split License.
- The two major bumps (`ModelContextProtocol` 1.x → 2.x, `SSH.NET` 2025 → 2026) required no source changes.
- No CHANGELOG entry: dependency bumps are not user-facing, matching #338.
- The Radzen bump regenerates static assets, which live in the Enterprise repository and are handled there.

Full solution (CE + EE) builds with **no errors and no warnings**.
