### PR TITLE
docs: orphan snapshots, plus corrections found auditing the docs against the code

### DIFF
--- a/docs/user/docs/configuration/admin-area/clusters.md
+++ b/docs/user/docs/configuration/admin-area/clusters.md
@@ -99,4 +99,4 @@ SSH is configured per-cluster under **Proxmox VE Clusters → SSH Credentials**.
     !!! note "Timeout scope"
         The SSH timeout applies only to the **connection phase** (handshake), not to command execution duration.
 
-Use the **Test SSH** button to verify connectivity to all nodes before saving.
+Connectivity to the nodes is verified automatically when the cluster settings are saved.

--- a/docs/user/docs/configuration/admin-area/general-settings.md
+++ b/docs/user/docs/configuration/admin-area/general-settings.md
@@ -6,7 +6,7 @@ Global application configuration. Settings live in the database (not in `appsett
 
 - **Application** — app name, default theme, default language
 - <span class="ce"></span> **SMTP** — outbound email server
-- <span class="ee"></span> **Appearance** — logo, colours, login page customisation
+- <span class="ee"></span> **Appearance** — favicon and sign in page customisation
 - **Release Channel** — stable / pre-release for the Updater module
 
 ## Application
@@ -36,10 +36,9 @@ Customise how the UI looks to your users.
 
 | Field | Description |
 |-------|-------------|
-| **Logo** | Custom logo image shown in the top header and on the login page. |
-| **Favicon** | Browser tab icon. |
-| **Primary colour** | Overrides the default indigo theme accent. |
-| **Login page** | Background image, welcome text, footer text. |
+| **Favicon** | Browser tab icon. Maximum file size 1 MB. |
+| **Sign in page — Title** | Heading shown on the login page. |
+| **Sign in page — Description** | Text below the heading, written in Markdown. |
 
 Useful for MSPs and enterprises that want to brand the admin interface for their own customers.
 

--- a/docs/user/docs/configuration/appsettings-extra.md
+++ b/docs/user/docs/configuration/appsettings-extra.md
@@ -100,7 +100,12 @@ This document describes all configurable settings available in `appsettings.extr
           "Override": {
             "Microsoft": "Warning",
             "Microsoft.Hosting.Lifetime": "Warning",
-            "System": "Warning"
+            "System": "Warning",
+            "System.Net.Http.HttpClient": "Warning",
+            "LibGit2Sharp": "Warning",
+            "ZiggyCreatures.Caching.Fusion": "Warning",
+            "Polly": "Warning",
+            "Corsinvest.ProxmoxVE.Api": "Warning"
           }
         },
         "Properties": {
@@ -151,28 +156,17 @@ This document describes all configurable settings available in `appsettings.extr
       "Args": {
         "connectionString": "DefaultConnection",
         "tableName": "Logs",
-        "schemaName": "serilog",
+        "schemaName": "logs_serilog",
         "needAutoCreateTable": true,
         "needAutoCreateSchema": true,
-        "columnOptionsSection": {
-          "message": "RenderedMessage",
-          "message_template": "MessageTemplate",
-          "level": "Level",
-          "raise_date": "Timestamp",
-          "exception": "Exception",
-          "properties": "LogEventSerialized",
-          "user_name": {
-            "Name": "SingleProperty",
-            "Args": { "propertyName": "UserName" }
-          },
-          "client_ip": {
-            "Name": "SingleProperty",
-            "Args": { "propertyName": "ClientIp" }
-          },
-          "source_context": {
-            "Name": "SingleProperty",
-            "Args": { "propertyName": "SourceContext" }
-          }
+        "loggerColumnOptions": {
+          "Id": { "Name": "IdAutoIncrement" },
+          "Timestamp": { "Name": "Timestamp" },
+          "Level": { "Name": "Level" },
+          "Message": { "Name": "RenderedMessage" },
+          "MessageTemplate": { "Name": "Message" },
+          "Exception": { "Name": "Exception" },
+          "LogEvent": { "Name": "LogEvent" }
         }
       }
     }
@@ -185,7 +179,7 @@ This document describes all configurable settings available in `appsettings.extr
     | `schemaName` | Database schema name |
     | `needAutoCreateTable` | Auto-create table if not exists |
     | `needAutoCreateSchema` | Auto-create schema if not exists |
-    | `columnOptionsSection` | Column mapping configuration |
+    | `loggerColumnOptions` | Column mapping configuration |
 
     **Console Sink**
 

--- a/docs/user/docs/configuration/pve-permissions.md
+++ b/docs/user/docs/configuration/pve-permissions.md
@@ -42,12 +42,13 @@ These are the permissions included in the built-in `PVEAuditor` role — equival
 | **Metrics Exporter** | — |
 | **Diagnostics** | — |
 | **System Report** | — |
-| **VM OS Info** | • `VM.GuestAgent.Audit` |
 | **AutoSnap** | • `VM.Snapshot`<br>• `VM.Snapshot.Rollback`<br>• `Datastore.AllocateSpace`<br>• `Pool.Allocate`<br>• `VM.PowerMgmt` _(only if Include RAM is enabled)_ |
 | **Node Protect** | Base only — uses SSH to operate on nodes |
 | **Update Manager** | Base only — uses SSH to operate on nodes/VMs |
 | **UPS Monitor** | — _(SNMP only, no PVE API)_ |
 | **VM Performance** | • `VM.Monitor` |
+| **AI Server** | Depends on which tools are enabled:<br>• Power state: `VM.PowerMgmt`<br>• Snapshots: `VM.Snapshot`, `VM.Snapshot.Rollback`<br>• Migrate: `VM.Migrate`<br>• Backup: `VM.Backup`, `Datastore.AllocateSpace`<br>• Delete backups / storage content: `Datastore.Allocate`<br>• Download ISO: `Datastore.AllocateTemplate`<br>_(read-only tools need base only; each tool is individually grantable)_ |
+| **Bots** | Depends on the commands enabled in the bot _(power and snapshot commands need `VM.PowerMgmt` and `VM.Snapshot`)_ |
 | **Portal** | • `VM.PowerMgmt`<br>• `VM.Console`<br>• `VM.Snapshot`<br>• `VM.Snapshot.Rollback`<br>• `VM.Backup`<br>• `Datastore.AllocateSpace`<br>_(depends on tenant permissions configured)_ |
 | **Workflow** | Depends on configured activities:<br>• Clone: `VM.Clone`, `Datastore.AllocateSpace`<br>• Backup: `VM.Backup`, `Datastore.AllocateSpace`<br>• Resize disk: `VM.Config.Disk`<br>• HA operations: `Sys.Modify`<br>• Node reboot/shutdown: `Sys.PowerMgmt`<br>• Convert to template: `VM.Allocate` |
 

--- a/docs/user/docs/modules/dashboard.md
+++ b/docs/user/docs/modules/dashboard.md
@@ -105,18 +105,23 @@ The Dashboard ships two generic widgets always available; every other module con
     | AutoSnap | Size | Snapshot size over time chart |
     | AutoSnap | Check | Failed snapshots alert |
     | AutoSnap | Info | Snapshot statistics and insights |
+    | AutoSnap | Daily Status | <span class="ee"></span> Successful and failed snapshots per day, last 14 days |
     | Backup Analytics | Status | Backup job status overview |
     | Backup Analytics | Size | Backup size chart |
     | Backup Analytics | Check | Failed backups alert |
     | Backup Analytics | Info | Backup statistics |
+    | Backup Analytics | Daily Status | <span class="ee"></span> Successful and failed backups per day, last 14 days |
     | Diagnostics | Status | Diagnostic check status |
     | Diagnostics | Check | Diagnostic issues list |
     | Replication Analytics | Status | Replication status overview |
     | Replication Analytics | Size | Replication size chart |
     | Replication Analytics | Check | Replication check alerts |
     | Replication Analytics | Info | Replication analytics overview |
+    | Replication Analytics | Daily Status | <span class="ee"></span> Successful and failed replications per day, last 14 days |
     | Node Protect | Folder Size | Node Protect backup folder size |
     | Node Protect | Git Size | <span class="ee"></span> Node Protect Git repository size |
+    | Node Protect | Daily Status | <span class="ee"></span> Successful and failed folder tasks per day, last 14 days |
+    | System Report | Daily Status | <span class="ee"></span> Successful and failed reports per day, last 14 days |
     | Update Manager | Status | Update Manager status overview |
 
 ## Default Dashboard

--- a/docs/user/docs/modules/resources.md
+++ b/docs/user/docs/modules/resources.md
@@ -96,7 +96,19 @@ Enterprise enables extra columns and detail data on Guests and other grids:
 
 - **Hostname** — collected via QEMU Guest Agent, useful when the VM name and the in-guest hostname differ
 - **OS Info** — OS family, distribution and version
+- **Orphan snapshots** — see below
 - Additional widgets in the [Dashboard](dashboard.md) feeding from Resources data
+
+### Orphan snapshots
+
+A snapshot removed in Proxmox VE can survive on the underlying storage: the removal does not always propagate to the dataset, and the space stays occupied. Proxmox VE no longer lists it, so nothing in its UI reveals it — the disk simply looks fuller than the snapshots explain.
+
+Opening a guest's **Snapshots** tab from Resources lists these first, marked as orphans, with a warning summing the space they hold. They cannot be rolled back, edited or deleted from here, since Proxmox VE has no snapshot to act on: removing one means working on the storage directly, on the node.
+
+!!! note "Requires SSH"
+    Orphan detection compares what the storage holds against what Proxmox VE reports, so it needs the same [SSH credentials](../configuration/admin-area/clusters.md#ssh-configuration) as snapshot size calculation. Without them, neither is shown.
+
+Sizes are read per storage type. On ZFS the reported size is the space the snapshot actually occupies; on other backends it is currently an approximation.
 
 ## Console Limitations
 

--- a/docs/user/docs/user_guide.md
+++ b/docs/user/docs/user_guide.md
@@ -17,7 +17,7 @@ The Command Palette provides fast access to navigation, search, and commands —
 
 ### Search
 
-Type any text to search across modules, VMs, nodes, storages, and pools.
+Type any text to search across modules, VMs and nodes.
 
 When the palette opens with an **empty query**, it shows suggested modules and available commands.
 
@@ -29,8 +29,6 @@ Use prefixes to narrow results to a specific resource type. Filters require a cl
 |--------|-------------|---------|
 | `vm:` | Filter by Virtual Machine or Container | `vm:101`, `vm:debian` |
 | `node:` | Filter by Node | `node:pve1` |
-| `storage:` | Filter by Storage | `storage:local` |
-| `pool:` | Filter by Pool | `pool:dev` |
 | `ip:` | Filter by IP address (requires OS info) | `ip:192.168` |
 
 Filters can be combined with free text. For example: `vm: debian` searches for VMs matching "debian".


### PR DESCRIPTION
Two commits: the new orphan snapshots feature, and a set of corrections from auditing the whole docs tree against the current source.

### Orphan snapshots

Documents the feature added in #346 — what orphan snapshots are, where they appear, why they cannot be acted on from the UI, and the SSH requirement they share with snapshot size calculation.

### Corrections

Each one verified against the source before changing.

**`appsettings-extra.md` — the documented PostgreSQL sink block does not bind.** The key is `loggerColumnOptions`, not `columnOptionsSection`; its child keys are named differently; the schema is `logs_serilog`, not `serilog`. Anyone copying the documented block got no logging configuration, silently. The `MinimumLevel` example was also missing five overrides that ship in `appsettings.json`.

**`general-settings.md` — Appearance described features that do not exist.** Logo, primary colour and login page background are commented out in `Appearance.razor`. What the panel actually offers: favicon, and the sign in page title and description.

**`user_guide.md` — `storage:` and `pool:` prefixes are not active** (commented out in `PveSearchProvider.cs`), and search does not span storages or pools.

**`pve-permissions.md`** — "VM OS Info" is not a module, and its permission was already in the Dashboard/Resources row. Added **AI Server**, whose tools perform writes (power state, snapshots, migrate, backup, ISO download) needing grants beyond the base set, and **Bots**.

**`dashboard.md`** — five Daily Status widgets were missing from the table.

**`clusters.md`** — SSH connectivity is verified when cluster settings are saved; there is no Test SSH button.

### Not in this PR

The audit also turned up three code issues, left alone since this is a docs PR:

- The command palette filter is labelled "Vm/Ct" but `PveSearchProvider.cs:172` filters `VmType == Qemu`, so containers never appear
- `RequiredUniqueChars` binds from configuration but is never applied to `options.Password`
- Label typo `"Sync form remote"` in the Node Protect Git panel

And several documentation gaps too large to fix here: no module page documents its permission constants, the required `Urls` setting is undocumented, and there are no pages for Subscription, Support, or Profile → Preferences.
