### PR TITLE
fix(profile): clear the password fields after a successful change

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Admin.Core/Components/PasswordField.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/Components/PasswordField.razor
@@ -20,7 +20,8 @@
                         aria-label="@Label" />
     </ChildContent>
     <End>
-        <RadzenToggleButton @bind-Value="@ShowPassword"
+        <RadzenToggleButton Value="@ShowPassword"
+                            ValueChanged="@((bool value) => SetShowPasswordAsync(value))"
                             Icon="visibility"
                             ToggleIcon="visibility_off"
                             Variant="Variant.Text"
@@ -50,5 +51,13 @@
     [Parameter] public AutoCompleteType AutoCompleteType { get; set; } = AutoCompleteType.On;
     [Parameter(CaptureUnmatchedValues = true)] public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private bool ShowPassword { get; set; }
+    [Parameter] public bool ShowPassword { get; set; }
+    [Parameter] public EventCallback<bool> ShowPasswordChanged { get; set; }
+
+    private async Task SetShowPasswordAsync(bool value)
+    {
+        if (ShowPassword == value) { return; }
+        ShowPassword = value;
+        await ShowPasswordChanged.InvokeAsync(value);
+    }
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
+++ b/src/Corsinvest.ProxmoxVE.Admin.Core/translations/source.json
@@ -1138,5 +1138,12 @@
   "Bearer": "",
   "API Key": "",
   "{0} orphan snapshot(s) found on disk, taking {1}. They are unknown to Proxmox and cannot be managed from here.": "",
-  "Orphan on disk": ""
+  "Orphan on disk": "",
+  "Preferences": "",
+  "Two-factor authentication (2FA)": "",
+  "Update password": "",
+  "Old Password": "",
+  "New Password": "",
+  "Confirm Password": "",
+  "Your password has been changed": ""
 }

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Profile/Components/ChangePassword.razor
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Profile/Components/ChangePassword.razor
@@ -18,6 +18,7 @@
             <PasswordField Label="@L["Old Password"]"
                            Name="@nameof(Model.OldPassword)"
                            @bind-Value="@Model.OldPassword"
+                           @bind-ShowPassword="@ShowPasswords"
                            AutoCompleteType="AutoCompleteType.CurrentPassword">
                 <Helper>
                     <RadzenDataAnnotationValidator Component="@nameof(Model.OldPassword)" />
@@ -27,6 +28,7 @@
             <PasswordField Label="@L["New Password"]"
                            Name="@nameof(Model.NewPassword)"
                            @bind-Value="@Model.NewPassword"
+                           @bind-ShowPassword="@ShowPasswords"
                            AutoCompleteType="AutoCompleteType.NewPassword">
                 <Helper>
                     <RadzenDataAnnotationValidator Component="@nameof(Model.NewPassword)" />
@@ -36,6 +38,7 @@
             <PasswordField Label="@L["Confirm Password"]"
                            Name="@nameof(Model.ConfirmPassword)"
                            @bind-Value="@Model.ConfirmPassword"
+                           @bind-ShowPassword="@ShowPasswords"
                            AutoCompleteType="AutoCompleteType.NewPassword">
                 <Helper>
                     <RadzenDataAnnotationValidator Component="@nameof(Model.ConfirmPassword)" />

--- a/src/Corsinvest.ProxmoxVE.Admin.Module.Profile/Components/ChangePassword.razor.cs
+++ b/src/Corsinvest.ProxmoxVE.Admin.Module.Profile/Components/ChangePassword.razor.cs
@@ -10,6 +10,7 @@ public partial class ChangePassword(UserManager<ApplicationUser> userManager,
 {
     private string? Error { get; set; }
     private InputModel Model { get; set; } = new();
+    private bool ShowPasswords { get; set; }
 
     private class InputModel
     {
@@ -32,6 +33,12 @@ public partial class ChangePassword(UserManager<ApplicationUser> userManager,
         if (result.Succeeded)
         {
             await userManager.UpdateSecurityStampAsync(user);
+
+            // Leave nothing behind on screen: clear the fields and put any revealed password
+            // back under the dots.
+            Model = new();
+            ShowPasswords = false;
+
             notificationService.Success(L["Your password has been changed"]);
         }
         else


### PR DESCRIPTION
After changing the password from the profile, the form kept the old and new passwords on screen — and left them readable if the reveal toggle had been used.

Both are now cleared once the change goes through.

### PasswordField

`ShowPassword` was private, so a form had no way to put a revealed password back under the dots. It is now a bindable parameter:

```razor
<PasswordField @bind-Value="@Model.NewPassword" @bind-ShowPassword="@ShowPasswords" />
```

**Existing usages are unaffected.** The other 13 usages do not pass the parameter, so the field keeps its own state exactly as before — the toggle still works on its own.

### Change password form

The three fields share one `ShowPasswords` flag, so revealing one reveals all three — which is what you want when comparing a new password against its confirmation. After a successful change the model is replaced and the flag goes back to `false`.

Solution builds: 36 projects, 0 failed.
